### PR TITLE
Fix downloading in good quality

### DIFF
--- a/src/models/download.cpp
+++ b/src/models/download.cpp
@@ -88,7 +88,7 @@ bool Download::download(bool embedMetadata)
     std::string cmd{ "" };
 	if (getMediaFileType().isVideo())
 	{
-	    std::string format{ getQuality() == Quality::Best ? "bv*+ba/b" : getQuality() == Quality::Worst ? "wv*+wa/w" : "" };
+	    std::string format{ getQuality() == Quality::Best ? "bv*+ba/b" : getQuality() == Quality::Good ? "\"bv*[height<=720]+ba/b[height<=720]\"" : getQuality() == Quality::Worst ? "wv*+wa/w" : "" };
 		cmd = "yt-dlp --format " + format + " --remux-video " + getMediaFileType().toString() + " \"" + getVideoUrl() + "\" -o \"" + getSavePathWithoutExtension() + ".%(ext)s\"";
 		if(getSubtitles() != Subtitles::None)
 	    {


### PR DESCRIPTION
Currently downloading in good quality is totally broken, because nothing is passed to the "--format" flag, which results in invalid yt-dlp command.

According to the [yt-dlp documentation](https://github.com/yt-dlp/yt-dlp#format-selection-examples), it's possible to choose maximum video resolution. In my opinion, 1080p videos on YouTube are common enough to consider it as "minimal best", and so I consider 720p as "good", that's why I chose it in the code. But if you disagree, change it to whatever you think is appropriate, it's up to you.