### PR TITLE
Add missing `Ctrl+Q` quit shortcut

### DIFF
--- a/src/ui/views/mainwindow.cpp
+++ b/src/ui/views/mainwindow.cpp
@@ -100,6 +100,12 @@ MainWindow::MainWindow(GtkApplication* application, const MainWindowController& 
     g_signal_connect(m_actAbout, "activate", G_CALLBACK((void (*)(GSimpleAction*, GVariant*, gpointer))[](GSimpleAction*, GVariant*, gpointer data) { reinterpret_cast<MainWindow*>(data)->onAbout(); }), this);
     g_action_map_add_action(G_ACTION_MAP(m_gobj), G_ACTION(m_actAbout));
     gtk_application_set_accels_for_action(application, "win.about", new const char*[2]{ "F1", nullptr });
+    //Quit Action
+    m_actQuit = g_simple_action_new("quit", nullptr);
+    g_signal_connect(m_actQuit, "activate", G_CALLBACK((void (*)(GSimpleAction*, GVariant*, gpointer))[](GSimpleAction*, GVariant*, gpointer data) { reinterpret_cast<MainWindow*>(data)->onQuit(); }), this);
+    g_action_map_add_action(G_ACTION_MAP(m_gobj), G_ACTION(m_actQuit));
+    gtk_application_set_accels_for_action(application, "win.quit", new const char*[2]{ "<Ctrl>q", nullptr });
+
 }
 
 GtkWidget* MainWindow::gobj()
@@ -176,4 +182,12 @@ void MainWindow::onAbout()
                           "debug-info", "Dependencies:\n- yt-dlp Version 2022.10.04\n- ffmpeg Version 5.1.2",
                           "release-notes", m_controller.getAppInfo().getChangelog().c_str(),
                           nullptr);
+}
+
+void MainWindow::onQuit()
+{
+    if(!onCloseRequest())
+    {
+        g_application_quit(G_APPLICATION(gtk_window_get_application(GTK_WINDOW(m_gobj))));
+    }
 }

--- a/src/ui/views/mainwindow.hpp
+++ b/src/ui/views/mainwindow.hpp
@@ -49,6 +49,7 @@ namespace NickvisionTubeConverter::UI::Views
 		GSimpleAction* m_actPreferences{ nullptr };
 		GSimpleAction* m_actKeyboardShortcuts{ nullptr };
 		GSimpleAction* m_actAbout{ nullptr };
+		GSimpleAction* m_actQuit{ nullptr };
 		std::vector<std::unique_ptr<NickvisionTubeConverter::UI::Controls::DownloadRow>> m_downloadRows;
 		/**
 		 * Runs closing functions
@@ -70,5 +71,9 @@ namespace NickvisionTubeConverter::UI::Views
 		 * Displays the about dialog
 		 */
 		void onAbout();
+		/**
+		 * Quits the app
+		 */
+		void onQuit();
 	};
 }

--- a/src/ui/views/shortcutsdialog.cpp
+++ b/src/ui/views/shortcutsdialog.cpp
@@ -48,6 +48,12 @@ ShortcutsDialog::ShortcutsDialog(GtkWindow* parent)
                             <child>
                                 <object class="GtkShortcutsShortcut">
                                     <property name="title">%s</property>
+                                    <property name="accelerator">&lt;Control&gt;q</property>
+                                </object>
+                            </child>
+                            <child>
+                                <object class="GtkShortcutsShortcut">
+                                    <property name="title">%s</property>
                                     <property name="accelerator">F1</property>
                                 </object>
                             </child>
@@ -63,6 +69,7 @@ ShortcutsDialog::ShortcutsDialog(GtkWindow* parent)
     _("Application"),
     _("Preferences"),
     _("Keyboard Shortcuts"),
+    _("Quit"),
     _("About")
     );
     GtkBuilder* builder{ gtk_builder_new_from_string(m_xml.c_str(), -1) };


### PR DESCRIPTION
`Ctrl+Q` is a standard shortcut to quit an application in the [GNOME Human Interface Guidelines](https://developer.gnome.org/hig/reference/keyboard.html)