### PR TITLE
Save Path

### DIFF
--- a/NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs
+++ b/NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs
@@ -222,6 +222,10 @@ public partial class AddDownloadDialog
     {
         var fileDialog = Gtk.FileChooserNative.New(_controller.Localizer["SelectSavePath"], _parent, Gtk.FileChooserAction.Save, _controller.Localizer["OK"], _controller.Localizer["Cancel"]);
         fileDialog.SetModal(true);
+        var filter = Gtk.FileFilter.New();
+        filter.SetName(((MediaFileType)_rowFileType.GetSelected()).GetDotExtension());
+        filter.AddPattern($"*{((MediaFileType)_rowFileType.GetSelected()).GetDotExtension()}");
+        fileDialog.SetFilter(filter);
         if (_rowSavePath.GetText().Length > 0)
         {
             var folder = Gio.FileHelper.NewForPath(Path.GetDirectoryName(_rowSavePath.GetText()));

--- a/NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs
+++ b/NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs
@@ -173,8 +173,16 @@ public partial class AddDownloadDialog
     private async Task ValidateAsync()
     {
         _spinnerVideoUrl.Start();
+        _rowFileType.SetSensitive(false);
+        _rowSavePath.SetSensitive(false);
+        _rowQuality.SetSensitive(false);
+        _rowSubtitle.SetSensitive(false);
         var checkStatus = await _controller.UpdateDownloadAsync(_rowVideoUrl.GetText(), (MediaFileType)_rowFileType.GetSelected(), _rowSavePath.GetText(), (Quality)_rowQuality.GetSelected(), (Subtitle)_rowSubtitle.GetSelected());
         _spinnerVideoUrl.Stop();
+        _rowFileType.SetSensitive(true);
+        _rowSavePath.SetSensitive(true);
+        _rowQuality.SetSensitive(true);
+        _rowSubtitle.SetSensitive(true);
         _rowVideoUrl.RemoveCssClass("error");
         _rowVideoUrl.SetTitle(_controller.Localizer["VideoUrl", "Field"]);
         _rowSavePath.RemoveCssClass("error");

--- a/NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs
+++ b/NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs
@@ -84,7 +84,6 @@ public partial class AddDownloadDialog
         {
             if (e.Pspec.GetName() == "selected-item")
             {
-                _rowSubtitle!.SetSensitive(((MediaFileType)_rowFileType.GetSelected()).GetIsVideo());
                 if (!_constructing)
                 {
                     await ValidateAsync();
@@ -209,7 +208,7 @@ public partial class AddDownloadDialog
         _rowFileType.SetSensitive(true);
         _rowSavePath.SetSensitive(true);
         _rowQuality.SetSensitive(true);
-        _rowSubtitle.SetSensitive(true);
+        _rowSubtitle.SetSensitive(((MediaFileType)_rowFileType.GetSelected()).GetIsVideo());
         _rowVideoUrl.RemoveCssClass("error");
         _rowVideoUrl.SetTitle(_controller.Localizer["VideoUrl", "Field"]);
         _rowSavePath.RemoveCssClass("error");

--- a/NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs
+++ b/NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs
@@ -121,16 +121,6 @@ public class AddDownloadDialog
         _rowSavePath.SetTitle(_controller.Localizer["SaveFolder", "Field"]);
         _rowSavePath.AddSuffix(_btnSelectSavePath);
         _rowSavePath.SetEditable(false);
-        _rowSavePath.OnNotify += async (sender, e) =>
-        {
-            if (e.Pspec.GetName() == "text")
-            {
-                if (!_constructing)
-                {
-                    await ValidateAsync();
-                }
-            }
-        };
         _preferencesGroup.Add(_rowSavePath);
         //Layout
         _dialog.SetExtraChild(_preferencesGroup);
@@ -138,7 +128,6 @@ public class AddDownloadDialog
         _rowVideoUrl.AddCssClass("error");
         _rowVideoUrl.SetTitle(_controller.Localizer["VideoUrl", "Empty"]);
         _rowFileType.SetSelected((uint)_controller.PreviousMediaFileType);
-        _rowSavePath.SetText(_controller.PreviousSaveFolder + Path.DirectorySeparatorChar + "video.mp4");
         if(string.IsNullOrEmpty(_rowSavePath.GetText()))
         {
             _rowSavePath.AddCssClass("error");
@@ -182,6 +171,7 @@ public class AddDownloadDialog
         _rowVideoUrl.SetTitle(_controller.Localizer["VideoUrl", "Field"]);
         _rowSavePath.RemoveCssClass("error");
         _rowSavePath.SetTitle(_controller.Localizer["SaveFolder", "Field"]);
+        _rowSavePath.SetText(_controller.GetSavePath());
         if (checkStatus == DownloadCheckStatus.Valid)
         {
             _dialog.SetResponseEnabled("ok", true);
@@ -216,6 +206,7 @@ public class AddDownloadDialog
     {
         var fileDialog = Gtk.FileChooserNative.New(_controller.Localizer["SelectSaveFolder"], _parent, Gtk.FileChooserAction.Save, _controller.Localizer["OK"], _controller.Localizer["Cancel"]);
         fileDialog.SetModal(true);
+        //fileDialog.SetFile(Gio.FileHelper.NewForPath(_rowSavePath.GetText()), null);
         fileDialog.OnResponse += async (sender, e) =>
         {
             if (e.ResponseId == (int)Gtk.ResponseType.Accept)

--- a/NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs
+++ b/NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs
@@ -3,6 +3,7 @@ using NickvisionTubeConverter.Shared.Models;
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace NickvisionTubeConverter.GNOME.Views;
@@ -29,6 +30,10 @@ public partial class AddDownloadDialog
     private readonly Adw.ComboRow _rowFileType;
     private readonly Adw.ComboRow _rowQuality;
     private readonly Adw.ComboRow _rowSubtitle;
+    private readonly Gtk.Label _lblSaveWarning;
+    private readonly Adw.Clamp _clampSaveWarning;
+    private readonly Gtk.Popover _popoverSaveWarning;
+    private readonly Gtk.MenuButton _btnSaveWarning;
     private readonly Gtk.Button _btnSelectSavePath;
     private readonly Adw.EntryRow _rowSavePath;
 
@@ -118,6 +123,21 @@ public partial class AddDownloadDialog
         };
         _preferencesGroup.Add(_rowSubtitle);
         //Save Path
+        _lblSaveWarning = Gtk.Label.New(_controller.Localizer["SaveWarning", "GTK"]);
+        _lblSaveWarning.SetWrap(true);
+        _lblSaveWarning.SetJustify(Gtk.Justification.Center);
+        _clampSaveWarning = Adw.Clamp.New();
+        _clampSaveWarning.SetMaximumSize(300);
+        _clampSaveWarning.SetChild(_lblSaveWarning);
+        _popoverSaveWarning = Gtk.Popover.New();
+        _popoverSaveWarning.SetChild(_clampSaveWarning);
+        _btnSaveWarning = Gtk.MenuButton.New();
+        _btnSaveWarning.SetIconName("dialog-warning-symbolic");
+        _btnSaveWarning.SetValign(Gtk.Align.Center);
+        _btnSaveWarning.AddCssClass("flat");
+        _btnSaveWarning.AddCssClass("warning");
+        _btnSaveWarning.SetPopover(_popoverSaveWarning);
+        _btnSaveWarning.SetVisible(false);
         _btnSelectSavePath = Gtk.Button.New();
         _btnSelectSavePath.SetValign(Gtk.Align.Center);
         _btnSelectSavePath.AddCssClass("flat");
@@ -127,8 +147,15 @@ public partial class AddDownloadDialog
         _rowSavePath = Adw.EntryRow.New();
         _rowSavePath.SetSizeRequest(420, -1);
         _rowSavePath.SetTitle(_controller.Localizer["SavePath", "Field"]);
+        _rowSavePath.AddSuffix(_btnSaveWarning);
         _rowSavePath.AddSuffix(_btnSelectSavePath);
         _rowSavePath.SetEditable(false);
+        _rowSavePath.OnNotify += (sender, e) => {
+            if (e.Pspec.GetName() == "text")
+            {
+                _btnSaveWarning.SetVisible(Regex.Match(_rowSavePath.GetText(), @"^\/run\/user\/.*\/doc\/.*").Success);
+            }
+        };
         _preferencesGroup.Add(_rowSavePath);
         //Layout
         _dialog.SetExtraChild(_preferencesGroup);

--- a/NickvisionTubeConverter.GNOME/org.nickvision.tubeconverter.json
+++ b/NickvisionTubeConverter.GNOME/org.nickvision.tubeconverter.json
@@ -19,8 +19,7 @@
         "--socket=wayland",
         "--device=dri",
         "--share=ipc",
-        "--share=network",
-        "--filesystem=home"
+        "--share=network"
     ],
     "cleanup": [
       "/include",

--- a/NickvisionTubeConverter.GNOME/org.nickvision.tubeconverter.json
+++ b/NickvisionTubeConverter.GNOME/org.nickvision.tubeconverter.json
@@ -19,7 +19,10 @@
         "--socket=wayland",
         "--device=dri",
         "--share=ipc",
-        "--share=network"
+        "--share=network",
+        "--filesystem=xdg-videos",
+        "--filesystem=xdg-music",
+        "--filesystem=xdg-download"
     ],
     "cleanup": [
       "/include",

--- a/NickvisionTubeConverter.Shared/Controllers/AddDownloadDialogController.cs
+++ b/NickvisionTubeConverter.Shared/Controllers/AddDownloadDialogController.cs
@@ -1,6 +1,7 @@
 using NickvisionTubeConverter.Shared.Helpers;
 using NickvisionTubeConverter.Shared.Models;
 using System.IO;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace NickvisionTubeConverter.Shared.Controllers;
@@ -106,7 +107,10 @@ public class AddDownloadDialogController
             return result;
         }
         Download = new Download(videoUrl, mediaFileType, SaveFolder, SaveFilename, quality, subtitles);
-        Configuration.Current.PreviousSaveFolder = SaveFolder;
+        if (!Regex.Match(SaveFolder, @"^\/run\/user\/.*\/doc\/.*").Success)
+        {
+            Configuration.Current.PreviousSaveFolder = SaveFolder;
+        }
         Configuration.Current.PreviousMediaFileType = mediaFileType;
         Configuration.Current.Save();
         return DownloadCheckStatus.Valid;

--- a/NickvisionTubeConverter.Shared/Controllers/AddDownloadDialogController.cs
+++ b/NickvisionTubeConverter.Shared/Controllers/AddDownloadDialogController.cs
@@ -61,12 +61,11 @@ public class AddDownloadDialogController
     /// </summary>
     /// <param name="videoUrl">The url of the video to download</param>
     /// <param name="mediaFileType">The file type to download the video as</param>
-    /// <param name="saveFolder">The folder to save the download to</param>
-    /// <param name="newFilename">The filename to save the download as</param>
+    /// <param name="savePath">The path to save the download to</param>
     /// <param name="quality">The quality of the download</param>
     /// <param name="subtitles">The subtitles for the download</param>
     /// <returns>The DownloadCheckStatus</returns>
-    public async Task<DownloadCheckStatus> UpdateDownloadAsync(string videoUrl, MediaFileType mediaFileType, string saveFolder, string newFilename, Quality quality, Subtitle subtitles)
+    public async Task<DownloadCheckStatus> UpdateDownloadAsync(string videoUrl, MediaFileType mediaFileType, string savePath, Quality quality, Subtitle subtitles)
     {
         DownloadCheckStatus result = 0;
         if (string.IsNullOrEmpty(videoUrl))
@@ -81,6 +80,8 @@ public class AddDownloadDialogController
                 result |= DownloadCheckStatus.InvalidVideoUrl;
             }
         }
+        var saveFolder = Path.GetDirectoryName(savePath);
+        var newFilename = Path.GetFileNameWithoutExtension(savePath);
         if (!Directory.Exists(saveFolder))
         {
             result |= DownloadCheckStatus.InvalidSaveFolder;

--- a/NickvisionTubeConverter.Shared/Controllers/AddDownloadDialogController.cs
+++ b/NickvisionTubeConverter.Shared/Controllers/AddDownloadDialogController.cs
@@ -83,8 +83,7 @@ public class AddDownloadDialogController
         else
         {
             SaveFolder = Path.GetDirectoryName(savePath);
-            SaveFilename = Path.GetFileName(savePath);
-            SaveFilename += SaveFilename.EndsWith(mediaFileType.GetDotExtension()) ? "" : mediaFileType.GetDotExtension();
+            SaveFilename = Path.GetFileNameWithoutExtension(savePath) + mediaFileType.GetDotExtension();
         }
         if (string.IsNullOrEmpty(videoUrl))
         {

--- a/NickvisionTubeConverter.Shared/Controllers/AddDownloadDialogController.cs
+++ b/NickvisionTubeConverter.Shared/Controllers/AddDownloadDialogController.cs
@@ -84,6 +84,7 @@ public class AddDownloadDialogController
         {
             SaveFolder = Path.GetDirectoryName(savePath);
             SaveFilename = Path.GetFileName(savePath);
+            SaveFilename += SaveFilename.EndsWith(mediaFileType.GetDotExtension()) ? "" : mediaFileType.GetDotExtension();
         }
         if (string.IsNullOrEmpty(videoUrl))
         {
@@ -98,7 +99,7 @@ public class AddDownloadDialogController
             }
             else
             {
-                SaveFilename = (await Download.GetVideoTitle(videoUrl)) + MediaFileTypeHelpers.GetDotExtension(mediaFileType);
+                SaveFilename = (await Download.GetVideoTitle(videoUrl)) + mediaFileType.GetDotExtension();
             }
         }
         if (result != 0)
@@ -112,5 +113,9 @@ public class AddDownloadDialogController
         return DownloadCheckStatus.Valid;
     }
 
+    /// <summary>
+    /// Gets full save path
+    /// </summary>
+    /// <returns>Save Path string</returns>
     public string GetSavePath() => SaveFolder + Path.DirectorySeparatorChar + SaveFilename;
 }

--- a/NickvisionTubeConverter.Shared/Models/Configuration.cs
+++ b/NickvisionTubeConverter.Shared/Models/Configuration.cs
@@ -49,7 +49,7 @@ public class Configuration
             Directory.CreateDirectory(ConfigDir);
         }
         Theme = Theme.System;
-        PreviousSaveFolder = "";
+        PreviousSaveFolder = Environment.GetFolderPath(Environment.SpecialFolder.MyVideos);
         PreviousMediaFileType = MediaFileType.MP4;
         EmbedMetadata = true;
         YtdlpVersion = new Version(0, 0, 0);

--- a/NickvisionTubeConverter.Shared/Models/Download.cs
+++ b/NickvisionTubeConverter.Shared/Models/Download.cs
@@ -34,7 +34,6 @@ public class Download
 {
     private CancellationTokenSource? _cancellationToken;
     private MediaFileType _fileType;
-    private string _newFilename;
     private Quality _quality;
     private Subtitle _subtitle;
 
@@ -64,16 +63,15 @@ public class Download
     /// <param name="newFilename">The filename to save the download as</param>
     /// <param name="quality">The quality of the download</param>
     /// <param name="subtitle">The subtitles for the download</param>
-    public Download(string videoUrl, MediaFileType fileType, string saveFolder, string newFilename = "", Quality quality = Quality.Best, Subtitle subtitle = Subtitle.None)
+    public Download(string videoUrl, MediaFileType fileType, string saveFolder, string saveFilename, Quality quality = Quality.Best, Subtitle subtitle = Subtitle.None)
     {
         _cancellationToken = null;
         _fileType = fileType;
-        _newFilename = newFilename;
         _quality = quality;
         _subtitle = subtitle;
         VideoUrl = videoUrl;
         SaveFolder = saveFolder;
-        Filename = _newFilename;
+        Filename = saveFilename;
         IsDone = false;
     }
 
@@ -104,14 +102,8 @@ public class Download
             FFmpegPath = DependencyManager.Ffmpeg,
         };
         RunResult<string>? result = null;
-        if (string.IsNullOrEmpty(Filename))
-        {
-            _newFilename = (await ytdlp.RunVideoDataFetch(VideoUrl)).Data.Title;
-            Filename += _newFilename;
-        }
-        Filename += Filename.EndsWith(_fileType.GetDotExtension()) ? "" : _fileType.GetDotExtension();
         ytdlp.OutputFolder = SaveFolder;
-        ytdlp.OutputFileTemplate = $"{_newFilename}.%(ext)s";
+        ytdlp.OutputFileTemplate = Filename;
         if (_fileType.GetIsAudio())
         {
             try
@@ -168,6 +160,11 @@ public class Download
     /// </summary>
     public void Stop() => _cancellationToken?.Cancel();
 
+    /// <summary>
+    /// Gets video title from metadata
+    /// </summary>
+    /// <param name="videoUrl">URL of video to get title from</param>
+    /// <returns>Title string</returns>
     public static async Task<string> GetVideoTitle(string videoUrl) => (await new YoutubeDL()
     {
         YoutubeDLPath = DependencyManager.YtdlpPath,

--- a/NickvisionTubeConverter.Shared/Models/Download.cs
+++ b/NickvisionTubeConverter.Shared/Models/Download.cs
@@ -167,4 +167,10 @@ public class Download
     /// Stops the download
     /// </summary>
     public void Stop() => _cancellationToken?.Cancel();
+
+    public static async Task<string> GetVideoTitle(string videoUrl) => (await new YoutubeDL()
+    {
+        YoutubeDLPath = DependencyManager.YtdlpPath,
+        FFmpegPath = DependencyManager.Ffmpeg,
+    }.RunVideoDataFetch(videoUrl)).Data.Title;
 }

--- a/NickvisionTubeConverter.Shared/Resources/Strings.resx
+++ b/NickvisionTubeConverter.Shared/Resources/Strings.resx
@@ -204,8 +204,8 @@
 		<value>Worst</value>
 	</data>
 
-	<data name="SelectSaveFolder" xml:space="preserve">
-		<value>Select Save Folder</value>
+	<data name="SelectSavePath" xml:space="preserve">
+		<value>Select Save Path</value>
 	</data>
 
 	<!--DownloadRow-->
@@ -316,12 +316,12 @@
 		<value>Subtitle</value>
 	</data>
 
-	<data name="SaveFolder.Field" xml:space="preserve">
-		<value>Save Folder</value>
+	<data name="SavePath.Field" xml:space="preserve">
+		<value>Save Path</value>
 	</data>
 
-	<data name="SaveFolder.Invalid" xml:space="preserve">
-		<value>Save Folder (Invalid)</value>
+	<data name="SavePath.Invalid" xml:space="preserve">
+		<value>Save Path (Invalid)</value>
 	</data>
 
 	<data name="NewFilename.Field" xml:space="preserve">

--- a/NickvisionTubeConverter.Shared/Resources/Strings.resx
+++ b/NickvisionTubeConverter.Shared/Resources/Strings.resx
@@ -369,4 +369,10 @@
 	<data name="Summary.GTK" xml:space="preserve">
 		<value>Download your favorite videos</value>
 	</data>
+
+	<data name="SaveWarning.GTK" xml:space="preserve">
+		<value>Looks like you want to save a file in a folder outside of Flatpak sandbox.
+
+Your file will be saved, but the folder path will not be remembered. If you want to always use this folder, give the application write permissions for it using Flatseal, then it will be remembered.</value>
+	</data>
 </root>

--- a/NickvisionTubeConverter.Shared/Resources/Strings.resx
+++ b/NickvisionTubeConverter.Shared/Resources/Strings.resx
@@ -371,8 +371,6 @@
 	</data>
 
 	<data name="SaveWarning.GTK" xml:space="preserve">
-		<value>Looks like you want to save a file in a folder outside of Flatpak sandbox.
-
-Your file will be saved, but the folder path will not be remembered. If you want to always use this folder, give the application write permissions for it using Flatseal, then it will be remembered.</value>
+		<value>The selected save folder is outside the Flatpak sandbox. The file will be saved, but the folder path will not be remembered for future use.&#xA;&#xA;If you want to always remember this folder, give Tube Converter Flatpak write permissions to the selected folder. (You can use Flatseal to achieve this task)</value>
 	</data>
 </root>

--- a/NickvisionTubeConverter.WinUI/Package.appxmanifest
+++ b/NickvisionTubeConverter.WinUI/Package.appxmanifest
@@ -4,6 +4,7 @@
   xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
+  xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10"
   xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
   IgnorableNamespaces="uap rescap mp">
 


### PR DESCRIPTION
This PR merges "Save Folder" and "New Filename" rows into one - "Save Path".

![](https://i.imgur.com/13e5GVV.png)

The entry itself is not editable, a path can only be changed using file chooser. This way a path can't be empty: either it's set by a user, or the controller generates new path using previously used folder (which is now never empty too, it defaults to Videos folder), a video title and selected file format. File chooser is filtered to show only files with selected format. During validation, all rows except URL become insensitive.
Home access removed from flatpak.