### PR TITLE
View Download Logs + Minor Fixes

### DIFF
--- a/NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp
+++ b/NickvisionTubeConverter.GNOME/Blueprints/add_download_dialog.blp
@@ -1,70 +1,77 @@
 using Gtk 4.0;
 using Adw 1;
 
-Adw.PreferencesGroup _preferencesGroup {
-  Adw.EntryRow _urlRow {
-    width-request: 420;
-    title: _("VideoUrl.Field");
-    
-    [suffix]
-    Gtk.Spinner _urlSpinner {
-      valign: center;
+Adw.MessageDialog _root {
+  heading: _("AddDownload");
+  default-width: 420;
+  hide-on-close: true;
+  modal: true;
+
+  Adw.PreferencesGroup {
+    Adw.EntryRow _urlRow {
+      width-request: 420;
+      title: _("VideoUrl.Field");
+      
+      [suffix]
+      Gtk.Spinner _urlSpinner {
+        valign: center;
+      }
     }
-  }
-  
-  Adw.ComboRow _fileTypeRow {
-    title: _("FileType.Field");
-    model: Gtk.StringList {
-      strings ["MP4", "WEBM", "MP3", "OPUS", "FLAC", "WAV"]
-    };
-  }
-  
-  Adw.ComboRow _qualityRow {
-    title: _("Quality.Field");
-    model: Gtk.StringList {
-      strings [_("Quality.Best"), _("Quality.Good"), _("Quality.Worst")]
-    };
-  }
-  
-  Adw.ComboRow _subtitleRow {
-    title: _("Subtitle.Field");
-    model: Gtk.StringList {
-      strings [_("Subtitle.None"), "VTT", "SRT"]
-    };
-  }
-  
-  Adw.EntryRow _savePathRow {
-    title: _("SavePath.Field");
-    width-request: 420;
-    editable: false;
     
-    [suffix]
-    Gtk.MenuButton _saveWarning {
-      valign: center;
-      icon-name: "dialog-warning-symbolic";
-      visible: false;
-      popover: Gtk.Popover {
-        Adw.Clamp {
-          maximum-size: 300;
-          
-          Gtk.Label {
-            label: _("SaveWarning.GTK");
-            wrap: true;
-            justify: center;
-          }
-        }
+    Adw.ComboRow _fileTypeRow {
+      title: _("FileType.Field");
+      model: Gtk.StringList {
+        strings ["MP4", "WEBM", "MP3", "OPUS", "FLAC", "WAV"]
       };
-      
-      styles ["flat", "warning"]
     }
     
-    [suffix]
-    Gtk.Button _selectPathButton {
-      valign: center;
-      icon-name: "folder-open-symbolic";
-      tooltip-text: _("SelectSavePath");
+    Adw.ComboRow _qualityRow {
+      title: _("Quality.Field");
+      model: Gtk.StringList {
+        strings [_("Quality.Best"), _("Quality.Good"), _("Quality.Worst")]
+      };
+    }
+    
+    Adw.ComboRow _subtitleRow {
+      title: _("Subtitle.Field");
+      model: Gtk.StringList {
+        strings [_("Subtitle.None"), "VTT", "SRT"]
+      };
+    }
+    
+    Adw.EntryRow _savePathRow {
+      title: _("SavePath.Field");
+      width-request: 420;
+      editable: false;
       
-      styles ["flat"]
+      [suffix]
+      Gtk.MenuButton _saveWarning {
+        valign: center;
+        icon-name: "dialog-warning-symbolic";
+        visible: false;
+        popover: Gtk.Popover {
+          Adw.Clamp {
+            maximum-size: 300;
+            
+            Gtk.Label {
+              label: _("SaveWarning.GTK");
+              wrap: true;
+              justify: center;
+            }
+          }
+        };
+        
+        styles ["flat", "warning"]
+      }
+      
+      [suffix]
+      Gtk.Button _selectPathButton {
+        valign: center;
+        icon-name: "folder-open-symbolic";
+        tooltip-text: _("SelectSavePath");
+        
+        styles ["flat"]
+      }
     }
   }
 }

--- a/NickvisionTubeConverter.GNOME/Blueprints/download_row.blp
+++ b/NickvisionTubeConverter.GNOME/Blueprints/download_row.blp
@@ -75,6 +75,14 @@ Gtk.Box _mainBox {
         }
       }
     }
+
+    Gtk.ToggleButton _viewLogToggleBtn {
+      valign: center;
+      icon-name: "dialog-information-symbolic";
+
+      styles ["circular"]
+    }
+
     Adw.ViewStack _actionViewStack {
       margin-start: 5;
       margin-end: 10;

--- a/NickvisionTubeConverter.GNOME/Blueprints/download_row.blp
+++ b/NickvisionTubeConverter.GNOME/Blueprints/download_row.blp
@@ -69,6 +69,22 @@ Gtk.Box _mainBox {
           }
         };
       }
+
+      Gtk.ScrolledWindow _scrollLog {
+        margin-top: 8;
+        height-request: 100;
+        child: Gtk.Label _lblLog {
+          margin-start: 6;
+          margin-top: 6;
+          margin-end: 6;
+          margin-bottom: 6;
+          wrap: true;
+
+          label: "Testing";
+        };
+
+        styles ["card", "view"]
+      }
     }
   }
   Adw.ViewStack _actionViewStack {

--- a/NickvisionTubeConverter.GNOME/Blueprints/download_row.blp
+++ b/NickvisionTubeConverter.GNOME/Blueprints/download_row.blp
@@ -2,126 +2,132 @@ using Gtk 4.0;
 using Adw 1;
 
 Gtk.Box _mainBox {
-  orientation: horizontal;
-  spacing: 6;
+  orientation: vertical;
+  spacing: 12;
 
-  Gtk.Image _statusIcon {
-    icon-name: "folder-download-symbolic";
-    pixel-size: 24;
-    margin-start: 10;
-    margin-end: 5;
-  }
-  
-  Gtk.Box {
-    orientation: vertical;
-    spacing: 3;
-    margin-top: 8;
-    margin-bottom: 8;
-    
-    Gtk.Label _filenameLabel {
-      halign: start;
-      ellipsize: end;
-      lines: 1;
+  Gtk.Box _contentBox {
+    orientation: horizontal;
+    spacing: 6;
+
+    Gtk.Image _statusIcon {
+      icon-name: "folder-download-symbolic";
+      pixel-size: 24;
+      margin-start: 10;
+      margin-end: 5;
     }
     
-    Gtk.Label _urlLabel {
-      halign: start;
-      ellipsize: end;
-      lines: 1;
-      
-      styles ["caption", "dim-label"]
-    }
-    
-    Adw.ViewStack _stateViewStack {
+    Gtk.Box {
+      orientation: vertical;
+      spacing: 3;
       margin-top: 8;
+      margin-bottom: 8;
       
-      Adw.ViewStackPage {
-        name: "downloading";
-        child: Gtk.Box {
-          orientation: vertical;
-          spacing: 3;
-          
-          Gtk.ProgressBar _progressBar {
-            hexpand: true;
-          }
-          
-          Gtk.Label  _progressLabel {
-            label: _("DownloadState.Waiting");
-            halign: start;
-            
-            styles ["caption"]
-          }
-        };
+      Gtk.Label _filenameLabel {
+        halign: start;
+        ellipsize: end;
+        lines: 1;
       }
       
-      Adw.ViewStackPage {
-        name: "done";
-        child: Gtk.Box {
-          orientation: vertical;
-          spacing: 3;
-          
-          Gtk.LevelBar _levelBar {}
-          
-          Gtk.Label _doneLabel {
-            halign: start;
+      Gtk.Label _urlLabel {
+        halign: start;
+        ellipsize: end;
+        lines: 1;
+        
+        styles ["caption", "dim-label"]
+      }
+      
+      Adw.ViewStack _stateViewStack {
+        margin-top: 8;
+        
+        Adw.ViewStackPage {
+          name: "downloading";
+          child: Gtk.Box {
+            orientation: vertical;
+            spacing: 3;
             
-            styles ["caption"]
-          }
+            Gtk.ProgressBar _progressBar {
+              hexpand: true;
+            }
+            
+            Gtk.Label  _progressLabel {
+              label: _("DownloadState.Waiting");
+              halign: start;
+              
+              styles ["caption"]
+            }
+          };
+        }
+        
+        Adw.ViewStackPage {
+          name: "done";
+          child: Gtk.Box {
+            orientation: vertical;
+            spacing: 3;
+            
+            Gtk.LevelBar _levelBar {}
+            
+            Gtk.Label _doneLabel {
+              halign: start;
+              
+              styles ["caption"]
+            }
+          };
+        }
+      }
+    }
+    Adw.ViewStack _actionViewStack {
+      margin-start: 5;
+      margin-end: 10;
+      
+      Adw.ViewStackPage {
+        name: "cancel";
+        child: Gtk.Button _stopButton {
+          valign: center;
+          icon-name: "media-playback-stop-symbolic";
+          tooltip-text: _("StopDownload");
+
+          styles ["circular"]
+        };
+      }
+
+      Adw.ViewStackPage {
+        name: "open-folder";
+        child: Gtk.Button  _openFolderButton {
+          valign: center;
+          icon-name: "folder-symbolic";
+          tooltip-text: _("OpenSaveFolder");
+
+          styles ["circular"]
+        };
+      }
+
+      Adw.ViewStackPage {
+        name: "retry";
+        child: Gtk.Button _retryButton {
+          valign: center;
+          icon-name: "view-refresh-symbolic";
+          tooltip-text: _("RetryDownload");
+            
+          styles ["circular"]
         };
       }
     }
-
-    Gtk.ScrolledWindow _scrollLog {
-      margin-top: 8;
-      height-request: 100;
-      child: Gtk.Label _lblLog {
-        margin-start: 6;
-        margin-top: 6;
-        margin-end: 6;
-        margin-bottom: 6;
-        wrap: true;
-
-        label: "Testing";
-      };
-
-      styles ["card", "view"]
-    }
   }
-  Adw.ViewStack _actionViewStack {
-    margin-start: 5;
-    margin-end: 10;
-    
-    Adw.ViewStackPage {
-      name: "cancel";
-      child: Gtk.Button _stopButton {
-        valign: center;
-        icon-name: "media-playback-stop-symbolic";
-        tooltip-text: _("StopDownload");
 
-        styles ["circular"]
-      };
-    }
+  Gtk.ScrolledWindow _scrollLog {
+    margin-start: 6;
+    margin-end: 6;
+    margin-bottom: 6;
+    height-request: 100;
+    child: Gtk.Label _lblLog {
+      margin-start: 6;
+      margin-top: 6;
+      margin-end: 6;
+      margin-bottom: 6;
+      halign: start;
+      wrap: true;
+    };
 
-    Adw.ViewStackPage {
-      name: "open-folder";
-      child: Gtk.Button  _openFolderButton {
-        valign: center;
-        icon-name: "folder-symbolic";
-        tooltip-text: _("OpenSaveFolder");
-
-        styles ["circular"]
-      };
-    }
-
-    Adw.ViewStackPage {
-      name: "retry";
-      child: Gtk.Button _retryButton {
-        valign: center;
-        icon-name: "view-refresh-symbolic";
-        tooltip-text: _("RetryDownload");
-          
-        styles ["circular"]
-      };
-    }
+    styles ["card", "view"]
   }
 }

--- a/NickvisionTubeConverter.GNOME/Blueprints/download_row.blp
+++ b/NickvisionTubeConverter.GNOME/Blueprints/download_row.blp
@@ -78,7 +78,7 @@ Gtk.Box _mainBox {
 
     Gtk.ToggleButton _viewLogToggleBtn {
       valign: center;
-      icon-name: "dialog-information-symbolic";
+      icon-name: "accessories-text-editor-symbolic";
 
       styles ["circular"]
     }

--- a/NickvisionTubeConverter.GNOME/Blueprints/download_row.blp
+++ b/NickvisionTubeConverter.GNOME/Blueprints/download_row.blp
@@ -129,7 +129,7 @@ Adw.Bin _root {
       margin-end: 6;
       margin-bottom: 6;
       height-request: 100;
-      visible: false;
+      visible: bind _viewLogToggleBtn.active;
       child: Gtk.Label _lblLog {
         margin-start: 6;
         margin-top: 6;

--- a/NickvisionTubeConverter.GNOME/Blueprints/download_row.blp
+++ b/NickvisionTubeConverter.GNOME/Blueprints/download_row.blp
@@ -1,7 +1,7 @@
 using Gtk 4.0;
 using Adw 1;
 
-Adw.Bin {
+Adw.Bin _root {
   Gtk.Box {
     orientation: vertical;
     spacing: 12;

--- a/NickvisionTubeConverter.GNOME/Blueprints/download_row.blp
+++ b/NickvisionTubeConverter.GNOME/Blueprints/download_row.blp
@@ -138,7 +138,7 @@ Adw.Bin _root {
         halign: end;
         valign: end;
         margin-bottom: 10;
-        margin-end: 16;
+        margin-end: 14;
 
         styles ["opaque"]
       }

--- a/NickvisionTubeConverter.GNOME/Blueprints/download_row.blp
+++ b/NickvisionTubeConverter.GNOME/Blueprints/download_row.blp
@@ -69,22 +69,22 @@ Gtk.Box _mainBox {
           }
         };
       }
+    }
 
-      Gtk.ScrolledWindow _scrollLog {
-        margin-top: 8;
-        height-request: 100;
-        child: Gtk.Label _lblLog {
-          margin-start: 6;
-          margin-top: 6;
-          margin-end: 6;
-          margin-bottom: 6;
-          wrap: true;
+    Gtk.ScrolledWindow _scrollLog {
+      margin-top: 8;
+      height-request: 100;
+      child: Gtk.Label _lblLog {
+        margin-start: 6;
+        margin-top: 6;
+        margin-end: 6;
+        margin-bottom: 6;
+        wrap: true;
 
-          label: "Testing";
-        };
+        label: "Testing";
+      };
 
-        styles ["card", "view"]
-      }
+      styles ["card", "view"]
     }
   }
   Adw.ViewStack _actionViewStack {

--- a/NickvisionTubeConverter.GNOME/Blueprints/download_row.blp
+++ b/NickvisionTubeConverter.GNOME/Blueprints/download_row.blp
@@ -127,6 +127,7 @@ Gtk.Box _mainBox {
     margin-end: 6;
     margin-bottom: 6;
     height-request: 100;
+    visible: false;
     child: Gtk.Label _lblLog {
       margin-start: 6;
       margin-top: 6;

--- a/NickvisionTubeConverter.GNOME/Blueprints/download_row.blp
+++ b/NickvisionTubeConverter.GNOME/Blueprints/download_row.blp
@@ -79,6 +79,7 @@ Gtk.Box _mainBox {
     Gtk.ToggleButton _viewLogToggleBtn {
       valign: center;
       icon-name: "accessories-text-editor-symbolic";
+      tooltip-text: _("ViewLog");
 
       styles ["circular"]
     }

--- a/NickvisionTubeConverter.GNOME/Blueprints/download_row.blp
+++ b/NickvisionTubeConverter.GNOME/Blueprints/download_row.blp
@@ -124,23 +124,39 @@ Adw.Bin _root {
       }
     }
 
-    Gtk.ScrolledWindow _scrollLog {
+    Gtk.Overlay _overlayLog {
       margin-start: 6;
       margin-end: 6;
       margin-bottom: 6;
-      height-request: 100;
       visible: bind _viewLogToggleBtn.active;
-      child: Gtk.Label _lblLog {
-        margin-start: 6;
-        margin-top: 6;
-        margin-end: 6;
-        margin-bottom: 6;
-        halign: start;
-        wrap: true;
-        selectable: true;
-      };
 
-      styles ["card", "view"]
+      [overlay]
+      Gtk.Button _btnLogToClipboard {
+        icon-name: "edit-copy-symbolic";
+        tooltip-text: _("CopyToClipboard");
+        vexpand: true;
+        halign: end;
+        valign: end;
+        margin-bottom: 10;
+        margin-end: 16;
+
+        styles ["opaque"]
+      }
+
+      Gtk.ScrolledWindow _scrollLog {
+        height-request: 100;
+        child: Gtk.Label _lblLog {
+          margin-start: 6;
+          margin-top: 6;
+          margin-end: 6;
+          margin-bottom: 6;
+          halign: start;
+          wrap: true;
+          selectable: true;
+        };
+
+        styles ["card", "view"]
+      }
     }
   }
 }

--- a/NickvisionTubeConverter.GNOME/Blueprints/download_row.blp
+++ b/NickvisionTubeConverter.GNOME/Blueprints/download_row.blp
@@ -1,143 +1,145 @@
 using Gtk 4.0;
 using Adw 1;
 
-Gtk.Box _mainBox {
-  orientation: vertical;
-  spacing: 12;
+Adw.Bin {
+  Gtk.Box {
+    orientation: vertical;
+    spacing: 12;
 
-  Gtk.Box _contentBox {
-    orientation: horizontal;
-    spacing: 6;
-
-    Gtk.Image _statusIcon {
-      icon-name: "folder-download-symbolic";
-      pixel-size: 24;
-      margin-start: 10;
-      margin-end: 5;
-    }
-    
     Gtk.Box {
-      orientation: vertical;
-      spacing: 3;
-      margin-top: 8;
-      margin-bottom: 8;
-      
-      Gtk.Label _filenameLabel {
-        halign: start;
-        ellipsize: end;
-        lines: 1;
+      orientation: horizontal;
+      spacing: 6;
+
+      Gtk.Image _statusIcon {
+        icon-name: "folder-download-symbolic";
+        pixel-size: 24;
+        margin-start: 10;
+        margin-end: 5;
       }
       
-      Gtk.Label _urlLabel {
-        halign: start;
-        ellipsize: end;
-        lines: 1;
-        
-        styles ["caption", "dim-label"]
-      }
-      
-      Adw.ViewStack _stateViewStack {
+      Gtk.Box {
+        orientation: vertical;
+        spacing: 3;
         margin-top: 8;
+        margin-bottom: 8;
         
-        Adw.ViewStackPage {
-          name: "downloading";
-          child: Gtk.Box {
-            orientation: vertical;
-            spacing: 3;
-            
-            Gtk.ProgressBar _progressBar {
-              hexpand: true;
-            }
-            
-            Gtk.Label  _progressLabel {
-              label: _("DownloadState.Waiting");
-              halign: start;
-              
-              styles ["caption"]
-            }
-          };
+        Gtk.Label _filenameLabel {
+          halign: start;
+          ellipsize: end;
+          lines: 1;
         }
         
-        Adw.ViewStackPage {
-          name: "done";
-          child: Gtk.Box {
-            orientation: vertical;
-            spacing: 3;
-            
-            Gtk.LevelBar _levelBar {}
-            
-            Gtk.Label _doneLabel {
-              halign: start;
+        Gtk.Label _urlLabel {
+          halign: start;
+          ellipsize: end;
+          lines: 1;
+          
+          styles ["caption", "dim-label"]
+        }
+        
+        Adw.ViewStack _stateViewStack {
+          margin-top: 8;
+          
+          Adw.ViewStackPage {
+            name: "downloading";
+            child: Gtk.Box {
+              orientation: vertical;
+              spacing: 3;
               
-              styles ["caption"]
-            }
+              Gtk.ProgressBar _progressBar {
+                hexpand: true;
+              }
+              
+              Gtk.Label  _progressLabel {
+                label: _("DownloadState.Waiting");
+                halign: start;
+                
+                styles ["caption"]
+              }
+            };
+          }
+          
+          Adw.ViewStackPage {
+            name: "done";
+            child: Gtk.Box {
+              orientation: vertical;
+              spacing: 3;
+              
+              Gtk.LevelBar _levelBar {}
+              
+              Gtk.Label _doneLabel {
+                halign: start;
+                
+                styles ["caption"]
+              }
+            };
+          }
+        }
+      }
+
+      Gtk.ToggleButton _viewLogToggleBtn {
+        valign: center;
+        icon-name: "accessories-text-editor-symbolic";
+        tooltip-text: _("ViewLog");
+
+        styles ["circular"]
+      }
+
+      Adw.ViewStack _actionViewStack {
+        margin-start: 5;
+        margin-end: 10;
+        
+        Adw.ViewStackPage {
+          name: "cancel";
+          child: Gtk.Button _stopButton {
+            valign: center;
+            icon-name: "media-playback-stop-symbolic";
+            tooltip-text: _("StopDownload");
+
+            styles ["circular"]
+          };
+        }
+
+        Adw.ViewStackPage {
+          name: "open-folder";
+          child: Gtk.Button  _openFolderButton {
+            valign: center;
+            icon-name: "folder-symbolic";
+            tooltip-text: _("OpenSaveFolder");
+
+            styles ["circular"]
+          };
+        }
+
+        Adw.ViewStackPage {
+          name: "retry";
+          child: Gtk.Button _retryButton {
+            valign: center;
+            icon-name: "view-refresh-symbolic";
+            tooltip-text: _("RetryDownload");
+              
+            styles ["circular"]
           };
         }
       }
     }
 
-    Gtk.ToggleButton _viewLogToggleBtn {
-      valign: center;
-      icon-name: "accessories-text-editor-symbolic";
-      tooltip-text: _("ViewLog");
-
-      styles ["circular"]
-    }
-
-    Adw.ViewStack _actionViewStack {
-      margin-start: 5;
-      margin-end: 10;
-      
-      Adw.ViewStackPage {
-        name: "cancel";
-        child: Gtk.Button _stopButton {
-          valign: center;
-          icon-name: "media-playback-stop-symbolic";
-          tooltip-text: _("StopDownload");
-
-          styles ["circular"]
-        };
-      }
-
-      Adw.ViewStackPage {
-        name: "open-folder";
-        child: Gtk.Button  _openFolderButton {
-          valign: center;
-          icon-name: "folder-symbolic";
-          tooltip-text: _("OpenSaveFolder");
-
-          styles ["circular"]
-        };
-      }
-
-      Adw.ViewStackPage {
-        name: "retry";
-        child: Gtk.Button _retryButton {
-          valign: center;
-          icon-name: "view-refresh-symbolic";
-          tooltip-text: _("RetryDownload");
-            
-          styles ["circular"]
-        };
-      }
-    }
-  }
-
-  Gtk.ScrolledWindow _scrollLog {
-    margin-start: 6;
-    margin-end: 6;
-    margin-bottom: 6;
-    height-request: 100;
-    visible: false;
-    child: Gtk.Label _lblLog {
+    Gtk.ScrolledWindow _scrollLog {
       margin-start: 6;
-      margin-top: 6;
       margin-end: 6;
       margin-bottom: 6;
-      halign: start;
-      wrap: true;
-    };
+      height-request: 100;
+      visible: false;
+      child: Gtk.Label _lblLog {
+        margin-start: 6;
+        margin-top: 6;
+        margin-end: 6;
+        margin-bottom: 6;
+        halign: start;
+        wrap: true;
+      };
 
-    styles ["card", "view"]
+      styles ["card", "view"]
+    }
   }
 }

--- a/NickvisionTubeConverter.GNOME/Blueprints/download_row.blp
+++ b/NickvisionTubeConverter.GNOME/Blueprints/download_row.blp
@@ -137,6 +137,7 @@ Adw.Bin _root {
         margin-bottom: 6;
         halign: start;
         wrap: true;
+        selectable: true;
       };
 
       styles ["card", "view"]

--- a/NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp
+++ b/NickvisionTubeConverter.GNOME/Blueprints/preferences_dialog.blp
@@ -1,46 +1,54 @@
 using Gtk 4.0;
 using Adw 1;
 
-Gtk.Box _mainBox {
-  orientation: vertical;
+Adw.PreferencesWindow _root {
+  default-width: 600;
+  default-height: 400;
+  modal: true;
+  destroy-with-parent: false;
+  hide-on-close: true;
 
-  Adw.HeaderBar {
-    title-widget: Adw.WindowTitle {
-      title: _("Preferences");
-    };
-  }
+  Gtk.Box {
+    orientation: vertical;
 
-  Adw.PreferencesPage {
-    Adw.PreferencesGroup {
-      title: _("UserInterface");
-      description: _("UserInterfaceDescription");
-
-      Adw.ComboRow _themeRow {
-        title: _("Theme");
-        model: Gtk.StringList {
-          strings [_("ThemeLight"), _("ThemeDark"), _("ThemeSystem")]
-        };
-      }
+    Adw.HeaderBar {
+      title-widget: Adw.WindowTitle {
+        title: _("Preferences");
+      };
     }
 
-    Adw.PreferencesGroup {
-      title: _("Converter");
-      description: _("Converter.Description");
+    Adw.PreferencesPage {
+      Adw.PreferencesGroup {
+        title: _("UserInterface");
+        description: _("UserInterfaceDescription");
 
-      Adw.ActionRow {
-        title: _("EmbedMetadata");
-        subtitle: _("EmbedMetadata.Description");
-
-        Gtk.Switch _embedMetadataSwitch {
-          valign: center;
+        Adw.ComboRow _themeRow {
+          title: _("Theme");
+          model: Gtk.StringList {
+            strings [_("ThemeLight"), _("ThemeDark"), _("ThemeSystem")]
+          };
         }
       }
 
-      Adw.ComboRow _maxNumberOfActiveDownloadsRow {
-        title: _("MaxNumberOfActiveDownloads");
-        model: Gtk.StringList {
-          strings ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]
-        };
+      Adw.PreferencesGroup {
+        title: _("Converter");
+        description: _("Converter.Description");
+
+        Adw.ActionRow {
+          title: _("EmbedMetadata");
+          subtitle: _("EmbedMetadata.Description");
+
+          Gtk.Switch _embedMetadataSwitch {
+            valign: center;
+          }
+        }
+
+        Adw.ComboRow _maxNumberOfActiveDownloadsRow {
+          title: _("MaxNumberOfActiveDownloads");
+          model: Gtk.StringList {
+            strings ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]
+          };
+        }
       }
     }
   }

--- a/NickvisionTubeConverter.GNOME/Blueprints/window.blp
+++ b/NickvisionTubeConverter.GNOME/Blueprints/window.blp
@@ -7,175 +7,180 @@ menu mainMenu {
   item(_("About"), "win.about")
 }
 
-Gtk.Overlay _root {
-  vexpand: true; 
+Adw.ApplicationWindow _root {
+  default-width: 800;
+  default-height: 600;
   
-  [overlay]
-  Adw.Bin _spinnerContainer {
-    hexpand: true;
-    vexpand: true;
+  Gtk.Overlay {
+    vexpand: true; 
     
-    Gtk.Spinner _spinner {
-      width-request: 48;
-      height-request: 48;
-      halign: center;
-      valign: center;
+    [overlay]
+    Adw.Bin _spinnerContainer {
       hexpand: true;
       vexpand: true;
-    }
-  }
-  
-  Gtk.Box _mainBox {
-    orientation: vertical;
-
-    Adw.HeaderBar {
-      title-widget: Adw.WindowTitle _title {};
       
-      [start]
-      Gtk.Button _addDownloadButton {
-        action-name: "win.addDownload";
-        tooltip-text: _("AddDownload.Tooltip");
-        Adw.ButtonContent {
-          icon-name: "list-add-symbolic";
-          label: _("Add");
-        }
-      }
-      
-      [end]
-      Gtk.MenuButton {
-        direction: none;
-        menu-model: mainMenu;
-        tooltip-text: _("MainMenu.GTK");
-        primary: true;
+      Gtk.Spinner _spinner {
+        width-request: 48;
+        height-request: 48;
+        halign: center;
+        valign: center;
+        hexpand: true;
+        vexpand: true;
       }
     }
     
-    Adw.ToastOverlay _toastOverlay {
-      hexpand: true;
-      vexpand: true;
-      Adw.ViewStack _viewStack {
-        Adw.ViewStackPage {
-          name: "pageNoDownloads";
-          child: Gtk.ScrolledWindow {
-            Adw.Clamp {
-              maximum-size: 450;
-              valign: center;
-              margin-start: 12;
-              margin-end: 12;
-              margin-top: 12;
-              margin-bottom: 12;
+    Gtk.Box _mainBox {
+      orientation: vertical;
 
-              Gtk.Box {
-                orientation: vertical;
-                spacing: 12;
-                hexpand: true;
-                halign: fill;
-                
-                Adw.ButtonContent _greeting {
-                  halign: center;
-                  margin-top: 24;
-                  margin-bottom: 14;
-                }
-                
-                Gtk.Button {
-                  label: _("AddDownload");
-                  halign: center;
-                  width-request: 200;
-                  height-request: 50;
-                  action-name: "win.addDownload";
-                  styles ["pill", "suggested-action"]
-                }
-                
-                Gtk.Label {
-                  label: _("NoDownloads.Description");
-                  wrap: true;
-                  justify: center;
-                  styles ["dim-label"]
-                }
-              }
-            }
-          };
+      Adw.HeaderBar {
+        title-widget: Adw.WindowTitle _title {};
+        
+        [start]
+        Gtk.Button _addDownloadButton {
+          action-name: "win.addDownload";
+          tooltip-text: _("AddDownload.Tooltip");
+          Adw.ButtonContent {
+            icon-name: "list-add-symbolic";
+            label: _("Add");
+          }
         }
         
-        Adw.ViewStackPage {
-          name: "pageDownloads";
-          child: Gtk.ScrolledWindow {
-            Adw.Clamp {
-              maximum-size: 800;
-              margin-start: 12;
-              margin-end: 12;
-              margin-top: 12;
-              margin-bottom: 12;
-              
-              Gtk.Box {
-                orientation: vertical;
-                spacing: 20;
-                hexpand: true;
-                valign: start;
-                    
+        [end]
+        Gtk.MenuButton {
+          direction: none;
+          menu-model: mainMenu;
+          tooltip-text: _("MainMenu.GTK");
+          primary: true;
+        }
+      }
+      
+      Adw.ToastOverlay _toastOverlay {
+        hexpand: true;
+        vexpand: true;
+        Adw.ViewStack _viewStack {
+          Adw.ViewStackPage {
+            name: "pageNoDownloads";
+            child: Gtk.ScrolledWindow {
+              Adw.Clamp {
+                maximum-size: 450;
+                valign: center;
+                margin-start: 12;
+                margin-end: 12;
+                margin-top: 12;
+                margin-bottom: 12;
 
-                Gtk.Box _sectionDownloading {
+                Gtk.Box {
                   orientation: vertical;
-                  spacing: 10;
-                  visible: false;
-
+                  spacing: 12;
+                  hexpand: true;
+                  halign: fill;
+                  
+                  Adw.ButtonContent _greeting {
+                    halign: center;
+                    margin-top: 24;
+                    margin-bottom: 14;
+                  }
+                  
+                  Gtk.Button {
+                    label: _("AddDownload");
+                    halign: center;
+                    width-request: 200;
+                    height-request: 50;
+                    action-name: "win.addDownload";
+                    styles ["pill", "suggested-action"]
+                  }
+                  
                   Gtk.Label {
-                    label: _("Downloading");
-                    halign: start;
-                    margin-start: 5;
-                    styles ["heading"]
-                  }
-                
-                  Gtk.Box _downloadingBox {
-                    orientation: vertical;
-                    hexpand: true;
-                    valign: start;
-                    styles ["card"]
-                  }
-                }
-
-                Gtk.Box _sectionCompleted {
-                  orientation: vertical;
-                  spacing: 10;
-                  visible: false;
-
-                  Gtk.Label {
-                    label: _("Completed");
-                    halign: start;
-                    margin-start: 5;
-                    styles ["heading"]
-                  }
-                
-                  Gtk.Box _completedBox {
-                    orientation: vertical;
-                    hexpand: true;
-                    valign: start;
-                    styles ["card"]
-                  }
-                }
-
-                Gtk.Box _sectionQueued {
-                  orientation: vertical;
-                  spacing: 10;
-                  visible: false;
-
-                  Gtk.Label {
-                    label: _("Queued");
-                    halign: start;
-                    margin-start: 5;
-                    styles ["heading"]
-                  }
-                
-                  Gtk.Box _queuedBox {
-                    orientation: vertical;
-                    hexpand: true;
-                    valign: start;
-                    styles ["card"]
+                    label: _("NoDownloads.Description");
+                    wrap: true;
+                    justify: center;
+                    styles ["dim-label"]
                   }
                 }
               }
-            }
-          };
+            };
+          }
+          
+          Adw.ViewStackPage {
+            name: "pageDownloads";
+            child: Gtk.ScrolledWindow {
+              Adw.Clamp {
+                maximum-size: 800;
+                margin-start: 12;
+                margin-end: 12;
+                margin-top: 12;
+                margin-bottom: 12;
+                
+                Gtk.Box {
+                  orientation: vertical;
+                  spacing: 20;
+                  hexpand: true;
+                  valign: start;
+                      
+
+                  Gtk.Box _sectionDownloading {
+                    orientation: vertical;
+                    spacing: 10;
+                    visible: false;
+
+                    Gtk.Label {
+                      label: _("Downloading");
+                      halign: start;
+                      margin-start: 5;
+                      styles ["heading"]
+                    }
+                  
+                    Gtk.Box _downloadingBox {
+                      orientation: vertical;
+                      hexpand: true;
+                      valign: start;
+                      styles ["card"]
+                    }
+                  }
+
+                  Gtk.Box _sectionCompleted {
+                    orientation: vertical;
+                    spacing: 10;
+                    visible: false;
+
+                    Gtk.Label {
+                      label: _("Completed");
+                      halign: start;
+                      margin-start: 5;
+                      styles ["heading"]
+                    }
+                  
+                    Gtk.Box _completedBox {
+                      orientation: vertical;
+                      hexpand: true;
+                      valign: start;
+                      styles ["card"]
+                    }
+                  }
+
+                  Gtk.Box _sectionQueued {
+                    orientation: vertical;
+                    spacing: 10;
+                    visible: false;
+
+                    Gtk.Label {
+                      label: _("Queued");
+                      halign: start;
+                      margin-start: 5;
+                      styles ["heading"]
+                    }
+                  
+                    Gtk.Box _queuedBox {
+                      orientation: vertical;
+                      hexpand: true;
+                      valign: start;
+                      styles ["card"]
+                    }
+                  }
+                }
+              }
+            };
+          }
         }
       }
     }

--- a/NickvisionTubeConverter.GNOME/Blueprints/window.blp
+++ b/NickvisionTubeConverter.GNOME/Blueprints/window.blp
@@ -10,6 +10,7 @@ menu mainMenu {
 Adw.ApplicationWindow _root {
   default-width: 800;
   default-height: 600;
+  width-request: 360;
   
   Gtk.Overlay {
     vexpand: true; 

--- a/NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs
+++ b/NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs
@@ -21,6 +21,7 @@ public partial class DownloadRow : Adw.Bin, IDownloadRowControl
     [LibraryImport("libadwaita-1.so.0", StringMarshalling = StringMarshalling.Utf8)]
     private static partial uint g_timeout_add(uint interval, GSourceFunc function, nint data);
 
+    private bool _disposed;
     private readonly Localizer _localizer;
     private readonly Download _download;
     private bool? _previousEmbedMetadata;
@@ -66,6 +67,7 @@ public partial class DownloadRow : Adw.Bin, IDownloadRowControl
 
     private DownloadRow(Gtk.Builder builder, Localizer localizer, Download download) : base(builder.GetPointer("_root"), false)
     {
+        _disposed = false;
         _localizer = localizer;
         _download = download;
         _previousEmbedMetadata = null;
@@ -92,6 +94,32 @@ public partial class DownloadRow : Adw.Bin, IDownloadRowControl
     /// <param name="download">The download displayed by the row</param>
     public DownloadRow(Localizer localizer, Download download) : this(Builder.FromFile("download_row.ui", localizer), localizer, download)
     {
+
+    }
+
+    /// <summary>
+    /// Frees resources used by the DownloadRow object
+    /// </summary>
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Frees resources used by the DownloadRow object
+    /// </summary>
+    protected virtual void Dispose(bool disposing)
+    {
+        if (_disposed)
+        {
+            return;
+        }
+        if (disposing)
+        {
+            _download.Dispose();
+        }
+        _disposed = true;
     }
 
     /// <summary>

--- a/NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs
+++ b/NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs
@@ -161,12 +161,12 @@ public partial class DownloadRow : Adw.Bin, IDownloadRowControl
                     break;
                 case DownloadProgressStatus.Processing:
                     _progressLabel.SetText(_localizer["DownloadState", "Processing"]);
+                    _lblLog.SetLabel(state.Log);
                     if (_processingCallback == null)
                     {
                         _processingCallback = (d) =>
                         {
                             _progressBar.Pulse();
-                            _lblLog.SetLabel(state.Log);
                             var vadjustment = _scrollLog.GetVadjustment();
                             vadjustment.SetValue(vadjustment.GetUpper() - vadjustment.GetPageSize());
                             _scrollLog.SetVadjustment(vadjustment);

--- a/NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs
+++ b/NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs
@@ -116,6 +116,9 @@ public partial class DownloadRow : Adw.Bin, IDownloadRowControl
         {
             _progressStatus = state.Status;
             _lblLog.SetLabel(state.Log);
+            var vadjustment = _scrollLog.GetVadjustment();
+            vadjustment.SetValue(vadjustment.GetUpper() - vadjustment.GetPageSize());
+            _scrollLog.SetVadjustment(vadjustment);
             switch (state.Status)
             {
                 case DownloadProgressStatus.Downloading:

--- a/NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs
+++ b/NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs
@@ -39,6 +39,7 @@ public partial class DownloadRow : Adw.Bin, IDownloadRowControl
     [Gtk.Connect] private readonly Gtk.Button _stopButton;
     [Gtk.Connect] private readonly Gtk.Button _openFolderButton;
     [Gtk.Connect] private readonly Gtk.Button _retryButton;
+    [Gtk.Connect] private readonly Gtk.Label _lblLog;
 
     private DownloadProgressStatus _progressStatus;
     private GSourceFunc? _processingCallback;
@@ -111,6 +112,7 @@ public partial class DownloadRow : Adw.Bin, IDownloadRowControl
         var success = await _download.RunAsync(embedMetadata, (state) =>
         {
             _progressStatus = state.Status;
+            _lblLog.SetLabel(state.Log);
             switch (state.Status)
             {
                 case DownloadProgressStatus.Downloading:

--- a/NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs
+++ b/NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs
@@ -39,6 +39,8 @@ public partial class DownloadRow : Adw.Bin, IDownloadRowControl
     [Gtk.Connect] private readonly Gtk.Button _stopButton;
     [Gtk.Connect] private readonly Gtk.Button _openFolderButton;
     [Gtk.Connect] private readonly Gtk.Button _retryButton;
+    [Gtk.Connect] private readonly Gtk.ToggleButton _viewLogToggleBtn;
+    [Gtk.Connect] private readonly Gtk.ScrolledWindow _scrollLog;
     [Gtk.Connect] private readonly Gtk.Label _lblLog;
 
     private DownloadProgressStatus _progressStatus;
@@ -87,6 +89,7 @@ public partial class DownloadRow : Adw.Bin, IDownloadRowControl
                 await DownloadRetriedAsyncCallback(this);
             }
         };
+        _viewLogToggleBtn.OnClicked += (sender, e) => _scrollLog.SetVisible(!_scrollLog.GetVisible());
         SetChild(_mainBox);
     }
 

--- a/NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs
+++ b/NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs
@@ -151,17 +151,16 @@ public partial class DownloadRow : Adw.Bin, IDownloadRowControl
                     {
                         _progressBar.SetFraction(state.Progress);
                         _progressLabel.SetText(string.Format(_localizer["DownloadState", "Downloading"], state.Progress * 100, state.Speed));
-                        _lblLog.SetLabel(state.Log);
+                        _lblLog.SetLabel(state.Log + "\n");
                         var vadjustment = _scrollLog.GetVadjustment();
                         vadjustment.SetValue(vadjustment.GetUpper() - vadjustment.GetPageSize());
-                        _scrollLog.SetVadjustment(vadjustment);
                         return false;
                     };
                     g_idle_add(_downloadingCallback, 0);
                     break;
                 case DownloadProgressStatus.Processing:
                     _progressLabel.SetText(_localizer["DownloadState", "Processing"]);
-                    _lblLog.SetLabel(state.Log);
+                    _lblLog.SetLabel(state.Log + "\n");
                     if (_processingCallback == null)
                     {
                         _processingCallback = (d) =>
@@ -169,7 +168,6 @@ public partial class DownloadRow : Adw.Bin, IDownloadRowControl
                             _progressBar.Pulse();
                             var vadjustment = _scrollLog.GetVadjustment();
                             vadjustment.SetValue(vadjustment.GetUpper() - vadjustment.GetPageSize());
-                            _scrollLog.SetVadjustment(vadjustment);
                             if (_progressStatus != DownloadProgressStatus.Processing || IsDone)
                             {
                                 _processingCallback = null;

--- a/NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs
+++ b/NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs
@@ -26,7 +26,6 @@ public partial class DownloadRow : Adw.Bin, IDownloadRowControl
     private bool? _previousEmbedMetadata;
     private bool _wasStopped;
 
-    [Gtk.Connect] private readonly Gtk.Box _mainBox;
     [Gtk.Connect] private readonly Gtk.Image _statusIcon;
     [Gtk.Connect] private readonly Gtk.Label _filenameLabel;
     [Gtk.Connect] private readonly Gtk.Label _urlLabel;
@@ -65,18 +64,13 @@ public partial class DownloadRow : Adw.Bin, IDownloadRowControl
     /// </summary>
     public bool IsDone => _download.IsDone;
 
-    /// <summary>
-    /// Constructs a DownloadRow
-    /// </summary>
-    /// <param name="download">The download displayed by the row</param>
-    public DownloadRow(Localizer localizer, Download download)
+    private DownloadRow(Gtk.Builder builder, Localizer localizer, Download download) : base(builder.GetPointer("_root"), false)
     {
         _localizer = localizer;
         _download = download;
         _previousEmbedMetadata = null;
         _wasStopped = false;
         //Build UI
-        var builder = Builder.FromFile("download_row.ui", _localizer);
         builder.Connect(this);
         _filenameLabel.SetLabel(download.Filename);
         _urlLabel.SetLabel(download.VideoUrl);
@@ -90,7 +84,14 @@ public partial class DownloadRow : Adw.Bin, IDownloadRowControl
             }
         };
         _viewLogToggleBtn.OnClicked += (sender, e) => _scrollLog.SetVisible(!_scrollLog.GetVisible());
-        SetChild(_mainBox);
+    }
+
+    /// <summary>
+    /// Constructs a DownloadRow
+    /// </summary>
+    /// <param name="download">The download displayed by the row</param>
+    public DownloadRow(Localizer localizer, Download download) : this(Builder.FromFile("download_row.ui", localizer), localizer, download)
+    {
     }
 
     /// <summary>

--- a/NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs
+++ b/NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs
@@ -123,10 +123,10 @@ public partial class DownloadRow : Adw.Bin, IDownloadRowControl
     }
 
     /// <summary>
-    /// Starts the download
+    /// Runs the download
     /// </summary>
     /// <param name="embedMetadata">Whether or not to embed video metadata</param>
-    public async Task StartAsync(bool embedMetadata)
+    public async Task RunAsync(bool embedMetadata)
     {
         if (_previousEmbedMetadata == null)
         {

--- a/NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs
+++ b/NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs
@@ -87,7 +87,6 @@ public partial class DownloadRow : Adw.Bin, IDownloadRowControl
                 await DownloadRetriedAsyncCallback(this);
             }
         };
-        _viewLogToggleBtn.OnClicked += (sender, e) => _scrollLog.SetVisible(!_scrollLog.GetVisible());
     }
 
     /// <summary>

--- a/NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs
+++ b/NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs
@@ -166,6 +166,10 @@ public partial class DownloadRow : Adw.Bin, IDownloadRowControl
                         _processingCallback = (d) =>
                         {
                             _progressBar.Pulse();
+                            _lblLog.SetLabel(state.Log);
+                            var vadjustment = _scrollLog.GetVadjustment();
+                            vadjustment.SetValue(vadjustment.GetUpper() - vadjustment.GetPageSize());
+                            _scrollLog.SetVadjustment(vadjustment);
                             if (_progressStatus != DownloadProgressStatus.Processing || IsDone)
                             {
                                 _processingCallback = null;

--- a/NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs
+++ b/NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs
@@ -144,10 +144,6 @@ public partial class DownloadRow : Adw.Bin, IDownloadRowControl
         var success = await _download.RunAsync(embedMetadata, (state) =>
         {
             _progressStatus = state.Status;
-            _lblLog.SetLabel(state.Log);
-            var vadjustment = _scrollLog.GetVadjustment();
-            vadjustment.SetValue(vadjustment.GetUpper() - vadjustment.GetPageSize());
-            _scrollLog.SetVadjustment(vadjustment);
             switch (state.Status)
             {
                 case DownloadProgressStatus.Downloading:
@@ -155,6 +151,10 @@ public partial class DownloadRow : Adw.Bin, IDownloadRowControl
                     {
                         _progressBar.SetFraction(state.Progress);
                         _progressLabel.SetText(string.Format(_localizer["DownloadState", "Downloading"], state.Progress * 100, state.Speed));
+                        _lblLog.SetLabel(state.Log);
+                        var vadjustment = _scrollLog.GetVadjustment();
+                        vadjustment.SetValue(vadjustment.GetUpper() - vadjustment.GetPageSize());
+                        _scrollLog.SetVadjustment(vadjustment);
                         return false;
                     };
                     g_idle_add(_downloadingCallback, 0);

--- a/NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs
+++ b/NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs
@@ -30,6 +30,7 @@ public partial class DownloadRow : Adw.Bin, IDownloadRowControl
     private GSourceFunc? _processingCallback;
     private GSourceFunc? _downloadingCallback;
     private string _logMessage;
+    private string _oldLogMessage;
 
     [Gtk.Connect] private readonly Gtk.Image _statusIcon;
     [Gtk.Connect] private readonly Gtk.Label _filenameLabel;
@@ -142,6 +143,7 @@ public partial class DownloadRow : Adw.Bin, IDownloadRowControl
         _filenameLabel.SetText(_download.Filename);
         _actionViewStack.SetVisibleChildName("cancel");
         _progressBar.SetFraction(0);
+        _oldLogMessage = "";
         var success = await _download.RunAsync(embedMetadata, (state) =>
         {
             _progressStatus = state.Status;
@@ -167,9 +169,13 @@ public partial class DownloadRow : Adw.Bin, IDownloadRowControl
                         _processingCallback = (d) =>
                         {
                             _progressBar.Pulse();
-                            _lblLog.SetLabel(_logMessage);
-                            var vadjustment = _scrollLog.GetVadjustment();
-                            vadjustment.SetValue(vadjustment.GetUpper() - vadjustment.GetPageSize());
+                            if (_logMessage != _oldLogMessage)
+                            {
+                                _lblLog.SetLabel(_logMessage);
+                                _oldLogMessage = _logMessage;
+                                var vadjustment = _scrollLog.GetVadjustment();
+                                vadjustment.SetValue(vadjustment.GetUpper() - vadjustment.GetPageSize());
+                            }
                             if (_progressStatus != DownloadProgressStatus.Processing || IsDone)
                             {
                                 _processingCallback = null;

--- a/NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs
+++ b/NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs
@@ -25,7 +25,6 @@ public partial class AddDownloadDialog : Adw.MessageDialog
     private readonly Gtk.Window _parent;
     private readonly AddDownloadDialogController _controller;
 
-    [Gtk.Connect] private readonly Adw.PreferencesGroup _preferencesGroup;
     [Gtk.Connect] private readonly Adw.EntryRow _urlRow;
     [Gtk.Connect] private readonly Gtk.Spinner _urlSpinner;
     [Gtk.Connect] private readonly Adw.ComboRow _fileTypeRow;
@@ -35,28 +34,20 @@ public partial class AddDownloadDialog : Adw.MessageDialog
     [Gtk.Connect] private readonly Gtk.MenuButton _saveWarning;
     [Gtk.Connect] private readonly Gtk.Button _selectPathButton;
 
-    /// <summary>
-    /// Constructs an AddDownloadDialog
-    /// </summary>
-    public AddDownloadDialog(AddDownloadDialogController controller, Gtk.Window parent)
+    private AddDownloadDialog(Gtk.Builder builder, AddDownloadDialogController controller, Gtk.Window parent) : base(builder.GetPointer("_root"), false)
     {
         _constructing = true;
         _parent = parent;
         _controller = controller;
         //Dialog Settings
-        SetHeading(_controller.Localizer["AddDownload"]);
         SetTransientFor(parent);
-        SetDefaultSize(420, -1);
-        SetHideOnClose(true);
-        SetModal(true);
-        AddResponse("cancel", _controller.Localizer["Cancel"]);
+        AddResponse("cancel", controller.Localizer["Cancel"]);
         SetCloseResponse("cancel");
-        AddResponse("ok", _controller.Localizer["Download"]);
+        AddResponse("ok", controller.Localizer["Download"]);
         SetDefaultResponse("ok");
         SetResponseAppearance("ok", Adw.ResponseAppearance.Suggested);
-        OnResponse += (sender, e) => _controller.Accepted = e.Response == "ok";
+        OnResponse += (sender, e) => controller.Accepted = e.Response == "ok";
         //Build UI
-        var builder = Builder.FromFile("add_download_dialog.ui", _controller.Localizer);
         builder.Connect(this);
         _urlRow.OnNotify += async (sender, e) =>
         {
@@ -106,11 +97,16 @@ public partial class AddDownloadDialog : Adw.MessageDialog
                 _saveWarning.SetVisible(Regex.Match(_savePathRow.GetText(), @"^\/run\/user\/.*\/doc\/.*").Success);
             }
         };
-        //Layout
-        SetExtraChild(_preferencesGroup);
         //Load
         _fileTypeRow.SetSelected((uint)_controller.PreviousMediaFileType);
         _constructing = false;
+    }
+
+    /// <summary>
+    /// Constructs an AddDownloadDialog
+    /// </summary>
+    public AddDownloadDialog(AddDownloadDialogController controller, Gtk.Window parent) : this(Builder.FromFile("add_download_dialog.ui", controller.Localizer), controller, parent)
+    {
     }
 
     /// <summary>

--- a/NickvisionTubeConverter.GNOME/Views/MainWindow.cs
+++ b/NickvisionTubeConverter.GNOME/Views/MainWindow.cs
@@ -118,7 +118,7 @@ public partial class MainWindow : Adw.ApplicationWindow
     /// </summary>
     /// <param name="sender">object?</param>
     /// <param name="e">NotificationSentEventArgs</param>
-    private void NotificationSent(object? sender, NotificationSentEventArgs e) => _toastOverlay.AddToast(Adw.Toast.New(e.Message));
+    public void NotificationSent(object? sender, NotificationSentEventArgs e) => _toastOverlay.AddToast(Adw.Toast.New(e.Message));
 
     /// <summary>
     /// Occurs when the window tries to close
@@ -148,7 +148,7 @@ public partial class MainWindow : Adw.ApplicationWindow
     /// <returns>The new download row</returns>
     private IDownloadRowControl CreateDownloadRow(Download download)
     {
-        var downloadRow = new DownloadRow(_controller.Localizer, download);
+        var downloadRow = new DownloadRow(this, _controller.Localizer, download);
         _addDownloadButton.SetVisible(true);
         _viewStack.SetVisibleChildName("pageDownloads");
         return downloadRow;

--- a/NickvisionTubeConverter.GNOME/Views/MainWindow.cs
+++ b/NickvisionTubeConverter.GNOME/Views/MainWindow.cs
@@ -118,7 +118,7 @@ public partial class MainWindow : Adw.ApplicationWindow
     /// </summary>
     /// <param name="sender">object?</param>
     /// <param name="e">NotificationSentEventArgs</param>
-    public void NotificationSent(object? sender, NotificationSentEventArgs e) => _toastOverlay.AddToast(Adw.Toast.New(e.Message));
+    private void NotificationSent(object? sender, NotificationSentEventArgs e) => _toastOverlay.AddToast(Adw.Toast.New(e.Message));
 
     /// <summary>
     /// Occurs when the window tries to close
@@ -148,7 +148,7 @@ public partial class MainWindow : Adw.ApplicationWindow
     /// <returns>The new download row</returns>
     private IDownloadRowControl CreateDownloadRow(Download download)
     {
-        var downloadRow = new DownloadRow(this, _controller.Localizer, download);
+        var downloadRow = new DownloadRow(download, _controller.Localizer, (e) => NotificationSent(null, e));
         _addDownloadButton.SetVisible(true);
         _viewStack.SetVisibleChildName("pageDownloads");
         return downloadRow;

--- a/NickvisionTubeConverter.GNOME/Views/MainWindow.cs
+++ b/NickvisionTubeConverter.GNOME/Views/MainWindow.cs
@@ -21,7 +21,6 @@ public partial class MainWindow : Adw.ApplicationWindow
     private Dictionary<IDownloadRowControl, Gtk.Separator> _completedSeparators;
     private Dictionary<IDownloadRowControl, Gtk.Separator> _queuedSeparators;
 
-    [Gtk.Connect] private readonly Gtk.Overlay _root;
     [Gtk.Connect] private readonly Adw.Bin _spinnerContainer;
     [Gtk.Connect] private readonly Gtk.Spinner _spinner;
     [Gtk.Connect] private readonly Gtk.Box _mainBox;
@@ -35,12 +34,7 @@ public partial class MainWindow : Adw.ApplicationWindow
     [Gtk.Connect] private readonly Gtk.Box _sectionQueued;
     [Gtk.Connect] private readonly Gtk.Box _queuedBox;
 
-    /// <summary>
-    /// Constructs a MainWindow
-    /// </summary>
-    /// <param name="controller">The MainWindowController</param>
-    /// <param name="application">The Adw.Application</param>
-    public MainWindow(MainWindowController controller, Adw.Application application)
+    private MainWindow(Gtk.Builder builder, MainWindowController controller, Adw.Application application) : base(builder.GetPointer("_root"), false)
     {
         //Window Settings
         _controller = controller;
@@ -48,8 +42,6 @@ public partial class MainWindow : Adw.ApplicationWindow
         _downloadingSeparators = new Dictionary<IDownloadRowControl, Gtk.Separator>();
         _completedSeparators = new Dictionary<IDownloadRowControl, Gtk.Separator>();
         _queuedSeparators = new Dictionary<IDownloadRowControl, Gtk.Separator>();
-        SetDefaultSize(800, 600);
-        SetSizeRequest(360, -1);
         SetTitle(_controller.AppInfo.ShortName);
         if (_controller.IsDevVersion)
         {
@@ -57,9 +49,7 @@ public partial class MainWindow : Adw.ApplicationWindow
         }
         OnCloseRequest += OnCloseRequested;
         //Build UI
-        var builder = Builder.FromFile("window.ui", _controller.Localizer, (s) => s == "About" ? string.Format(_controller.Localizer[s], _controller.AppInfo.ShortName) : _controller.Localizer[s]);
         builder.Connect(this);
-        SetContent(_root);
         //Update Title
         var windowTitle = (Adw.WindowTitle)builder.GetObject("_title");
         windowTitle.SetTitle(_controller.AppInfo.ShortName);
@@ -102,6 +92,15 @@ public partial class MainWindow : Adw.ApplicationWindow
         actAbout.OnActivate += About;
         AddAction(actAbout);
         application.SetAccelsForAction("win.about", new string[] { "F1" });
+    }
+
+    /// <summary>
+    /// Constructs a MainWindow
+    /// </summary>
+    /// <param name="controller">The MainWindowController</param>
+    /// <param name="application">The Adw.Application</param>
+    public MainWindow(MainWindowController controller, Adw.Application application) : this(Builder.FromFile("window.ui", controller.Localizer, (s) => s == "About" ? string.Format(controller.Localizer[s], controller.AppInfo.ShortName) : controller.Localizer[s]), controller, application)
+    {
     }
 
     /// <summary>

--- a/NickvisionTubeConverter.GNOME/Views/MainWindow.cs
+++ b/NickvisionTubeConverter.GNOME/Views/MainWindow.cs
@@ -169,7 +169,7 @@ public partial class MainWindow : Adw.ApplicationWindow
     private void MoveDownloadRow(IDownloadRowControl row, DownloadStage stage)
     {
         _downloadingBox.Remove((DownloadRow)row);
-        if(_downloadingSeparators.ContainsKey(row))
+        if (_downloadingSeparators.ContainsKey(row))
         {
             _downloadingBox.Remove(_downloadingSeparators[row]);
             _downloadingSeparators.Remove(row);

--- a/NickvisionTubeConverter.GNOME/Views/MainWindow.cs
+++ b/NickvisionTubeConverter.GNOME/Views/MainWindow.cs
@@ -185,36 +185,19 @@ public partial class MainWindow : Adw.ApplicationWindow
             _queuedBox.Remove(_queuedSeparators[row]);
             _queuedSeparators.Remove(row);
         }
-        if (stage == DownloadStage.InQueue)
+        var (box, separators) = stage switch
         {
-            if (_queuedBox.GetFirstChild() != null)
-            {
-                var separator = Gtk.Separator.New(Gtk.Orientation.Horizontal);
-                _queuedBox.Append(separator);
-                _queuedSeparators.Add(row, separator);
-            }
-            _queuedBox.Append((DownloadRow)row);
-        }
-        else if (stage == DownloadStage.Downloading)
+            DownloadStage.InQueue => (_queuedBox, _queuedSeparators),
+            DownloadStage.Downloading => (_downloadingBox, _downloadingSeparators),
+            DownloadStage.Completed => (_completedBox, _completedSeparators)
+        };
+        if (box.GetFirstChild() != null)
         {
-            if (_downloadingBox.GetFirstChild() != null)
-            {
-                var separator = Gtk.Separator.New(Gtk.Orientation.Horizontal);
-                _downloadingBox.Append(separator);
-                _downloadingSeparators.Add(row, separator);
-            }
-            _downloadingBox.Append((DownloadRow)row);
+            var separator = Gtk.Separator.New(Gtk.Orientation.Horizontal);
+            box.Append(separator);
+            _queuedSeparators.Add(row, separator);
         }
-        else if (stage == DownloadStage.Completed)
-        {
-            if (_completedBox.GetFirstChild() != null)
-            {
-                var separator = Gtk.Separator.New(Gtk.Orientation.Horizontal);
-                _completedBox.Append(separator);
-                _completedSeparators.Add(row, separator);
-            }
-            _completedBox.Append((DownloadRow)row);
-        }
+        box.Append((DownloadRow)row);
         _sectionDownloading.SetVisible(_downloadingBox.GetFirstChild() != null);
         _sectionCompleted.SetVisible(_completedBox.GetFirstChild() != null);
         _sectionQueued.SetVisible(_queuedBox.GetFirstChild() != null);

--- a/NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs
+++ b/NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs
@@ -13,31 +13,18 @@ public partial class PreferencesDialog : Adw.PreferencesWindow
     private readonly PreferencesViewController _controller;
     private readonly Adw.Application _application;
 
-    [Gtk.Connect] private readonly Gtk.Box _mainBox;
     [Gtk.Connect] private readonly Adw.ComboRow _themeRow;
     [Gtk.Connect] private readonly Gtk.Switch _embedMetadataSwitch;
     [Gtk.Connect] private readonly Adw.ComboRow _maxNumberOfActiveDownloadsRow;
 
-    /// <summary>
-    /// Constructs a PreferencesDialog
-    /// </summary>
-    /// <param name="controller">PreferencesViewController</param>
-    /// <param name="application">Adw.Application</param>
-    /// <param name="parent">Gtk.Window</param>
-    public PreferencesDialog(PreferencesViewController controller, Adw.Application application, Gtk.Window parent)
+    private PreferencesDialog(Gtk.Builder builder, PreferencesViewController controller, Adw.Application application, Gtk.Window parent) : base(builder.GetPointer("_root"), false)
     {
         //Window Settings
         _controller = controller;
         _application = application;
         SetTransientFor(parent);
-        SetDefaultSize(600, 400);
-        SetModal(true);
-        SetDestroyWithParent(false);
-        SetHideOnClose(true);
         //Build UI
-        var builder = Builder.FromFile("preferences_dialog.ui", _controller.Localizer);
         builder.Connect(this);
-        SetContent(_mainBox);
         //Theme
         _themeRow.OnNotify += (sender, e) =>
         {
@@ -51,6 +38,16 @@ public partial class PreferencesDialog : Adw.PreferencesWindow
         _themeRow.SetSelected((uint)_controller.Theme);
         _embedMetadataSwitch.SetActive(_controller.EmbedMetadata);
         _maxNumberOfActiveDownloadsRow.SetSelected((uint)(_controller.MaxNumberOfActiveDownloads - 1));
+    }
+
+    /// <summary>
+    /// Constructs a PreferencesDialog
+    /// </summary>
+    /// <param name="controller">PreferencesViewController</param>
+    /// <param name="application">Adw.Application</param>
+    /// <param name="parent">Gtk.Window</param>
+    public PreferencesDialog(PreferencesViewController controller, Adw.Application application, Gtk.Window parent) : this(Builder.FromFile("preferences_dialog.ui", controller.Localizer), controller, application, parent)
+    {
     }
 
     /// <summary>

--- a/NickvisionTubeConverter.GNOME/justfile
+++ b/NickvisionTubeConverter.GNOME/justfile
@@ -9,11 +9,11 @@ default:
 run:
     blueprint-compiler batch-compile Blueprints/ Blueprints/ Blueprints/*.blp
     dotnet build
-    rm Blueprints/*.ui
     glib-compile-resources --sourcedir ./Resources \
     ./Resources/{{app_id}}.gresource.xml
     mv ./Resources/{{app_id}}.gresource ./bin/Debug/net7.0/
     dotnet run
+    rm Blueprints/*.ui
 
 # Install the app
 publish PREFIX LIB_DIR=lib: && (_install_extras PREFIX)

--- a/NickvisionTubeConverter.GNOME/justfile
+++ b/NickvisionTubeConverter.GNOME/justfile
@@ -1,7 +1,18 @@
 app_id := "org.nickvision.tubeconverter"
 project_name := "NickvisionTubeConverter"
-lib := "lib" # this is added to prefix, see "publish" recipe for details
 
+dotnet_runtime := if arch() == "arm" {
+    "linux-arm"
+} else if arch() == "aarch64" {
+    "linux-arm64"
+} else {
+    "linux-x64"
+}
+
+builddir := env_var_or_default('NICK_BUILDDIR', '_nickbuild')
+lib := "lib" # this is added to installation prefix, see "publish" recipe for details
+
+# List all recipes
 default:
     @just --list
 
@@ -15,128 +26,107 @@ run:
     dotnet run
     rm Blueprints/*.ui
 
-# Install the app
-publish PREFIX LIB_DIR=lib: && (_install_extras PREFIX)
+# Publish the app
+publish PREFIX LIB_DIR=lib: clean && (_install_extras PREFIX)
     #!/bin/sh
     # LIB_DIR id added to prefix.
     # For example, for PREFIX "/usr" and LIB_DIR "lib"
     # all dll and so files will go to "/usr/lib".
     # Resources will go to {{PREFIX}}/shared.
+    # Build directory is "_nickbuild" by default,
+    # use NICK_BUILDDIR env var to change it.
 
-    ARCH={{arch()}}
-    if [ "$ARCH" == "x86_64" ]
-    then
-        RUNTIME="linux-x64"
-    elif [ "$ARCH" == "arm" ]
-    then
-        RUNTIME="linux-arm"
-    elif [ "$ARCH" == "aarch64" ]
-    then
-        RUNTIME="linux-arm64"
-    fi
-
+    mkdir -p {{builddir}}{{PREFIX}}/{{LIB_DIR}}/{{app_id}}
     blueprint-compiler batch-compile Blueprints/ Blueprints/ Blueprints/*.blp
-    mkdir -p {{PREFIX}}/{{LIB_DIR}}/{{app_id}}
     dotnet publish -c Release {{project_name}}.GNOME.csproj \
-        $([ "$RUNTIME" ] && echo "--runtime $RUNTIME") \
-        --self-contained false -o {{PREFIX}}/{{LIB_DIR}}/{{app_id}}
+        --runtime {{dotnet_runtime}} \
+        --self-contained false \
+        -o {{builddir}}{{PREFIX}}/{{LIB_DIR}}/{{app_id}}
+    success=$?
     rm Blueprints/*.ui
-    mkdir -p {{PREFIX}}/bin
-    cat > {{PREFIX}}/bin/{{app_id}} << EOF
+    if [ $success != 0 ]
+    then
+        exit $success
+    fi
+    mkdir -p {{builddir}}{{PREFIX}}/bin
+    cat > {{builddir}}{{PREFIX}}/bin/{{app_id}} << EOF
     #!/bin/sh
     exec dotnet {{PREFIX}}/{{LIB_DIR}}/{{app_id}}/{{project_name}}.GNOME.dll
     EOF
-    chmod +x {{PREFIX}}/bin/{{app_id}}
+    chmod +x {{builddir}}{{PREFIX}}/bin/{{app_id}}
 
-# Install the app (self-contained)
-publish-self-contained PREFIX LIB_DIR=lib: && (_install_extras PREFIX)
+# Publish the app (self-contained)
+publish-self-contained PREFIX LIB_DIR=lib: clean && (_install_extras PREFIX)
     #!/bin/sh
-    # BIN_DIR and LIB_DIR are added to prefix
-    # For example, for PREFIX "/usr" and BIN_DIR "/bin" the executable will go to "/usr/bin"
-    # All dll and so files will go to {{PREFIX}}/{{LIB_DIR}} (e.g. "/usr/lib")
-    # Resources will go to {{PREFIX}}/shared
+    # LIB_DIR id added to prefix.
+    # For example, for PREFIX "/usr" and LIB_DIR "lib"
+    # all dll and so files will go to "/usr/lib".
+    # Resources will go to {{PREFIX}}/shared.
+    # Build directory is "_nickbuild" by default,
+    # use NICK_BUILDDIR env var to change it.
 
-    ARCH={{arch()}}
-    if [ "$ARCH" == "x86_64" ]
-    then
-        RUNTIME="linux-x64"
-    elif [ "$ARCH" == "arm" ]
-    then
-        RUNTIME="linux-arm"
-    elif [ "$ARCH" == "aarch64" ]
-    then
-        RUNTIME="linux-arm64"
-    fi
-
+    mkdir -p {{builddir}}{{PREFIX}}/{{LIB_DIR}}/{{app_id}}
     blueprint-compiler batch-compile Blueprints/ Blueprints/ Blueprints/*.blp
-    mkdir -p {{PREFIX}}/{{LIB_DIR}}/{{app_id}}
-    dotnet publish -c Release {{project_name}}.GNOME.csproj \
-        $([ "$RUNTIME" ] && echo "--runtime $RUNTIME") \
-        --self-contained true -o {{PREFIX}}/{{LIB_DIR}}/{{app_id}}
-    rm Blueprints/*.ui
-    mkdir -p {{PREFIX}}/bin
-    cat > {{PREFIX}}/bin/{{app_id}} << EOF
-    #!/bin/sh
-    exec {{PREFIX}}/{{LIB_DIR}}/{{app_id}}/{{project_name}}.GNOME
-    EOF
-    chmod +x {{PREFIX}}/bin/{{app_id}}
-
-# Command to be used in flatpak manifest
-publish-flatpak: && (_install_extras "/app")
-    #!/bin/sh
-    ARCH={{arch()}}
-    if [ "$ARCH" == "x86_64" ]
-    then
-        RUNTIME="linux-x64"
-    elif [ "$ARCH" == "arm" ]
-    then
-        RUNTIME="linux-arm"
-    elif [ "$ARCH" == "aarch64" ]
-    then
-        RUNTIME="linux-arm64"
-    fi
-
-    blueprint-compiler batch-compile Blueprints/ Blueprints/ Blueprints/*.blp
-    mkdir -p /app/lib/{{app_id}}
     dotnet publish -c Release {{project_name}}.GNOME.csproj \
         $([ -d "$FLATPAK_BUILDER_BUILDDIR/nuget-sources" ] && \
         echo "--source $FLATPAK_BUILDER_BUILDDIR/nuget-sources") \
-        --runtime $RUNTIME --self-contained true -o /app/lib/{{app_id}}
+        --runtime {{dotnet_runtime}} \
+        --self-contained true \
+        -o {{builddir}}{{PREFIX}}/{{LIB_DIR}}/{{app_id}}
+    success=$?
     rm Blueprints/*.ui
-    mkdir -p /app/bin
-    cat > /app/bin/{{app_id}} << EOF
+    if [ $success != 0 ]
+    then
+        exit $success
+    fi
+    mkdir -p {{builddir}}{{PREFIX}}/bin
+    cat > {{builddir}}{{PREFIX}}/bin/{{app_id}} << EOF
     #!/bin/sh
-    exec /app/lib/{{app_id}}/{{project_name}}.GNOME
+    exec {{PREFIX}}/{{LIB_DIR}}/{{app_id}}/{{project_name}}.GNOME
     EOF
-    chmod +x /app/bin/{{app_id}}
+    chmod +x {{builddir}}{{PREFIX}}/bin/{{app_id}}
+
+# Install the app
+install INSTALL_PREFIX="/":
+    # Installing the app to {{INSTALL_PREFIX}}
+    if [ ! -d {{INSTALL_PREFIX}} ]; then mkdir -p {{INSTALL_PREFIX}}; fi
+    cp -r {{builddir}}/* {{INSTALL_PREFIX}}
+
+# Clean build directory
+clean:
+    # Removing build directory
+    rm -r {{builddir}}; exit 0
+
+# Command to be used in flatpak manifest
+publish-flatpak: (publish-self-contained "/app") install && clean
 
 _install_extras PREFIX: && (_translate_meta PREFIX)
     # Installing icons
-    mkdir -p {{PREFIX}}/share/icons/hicolor/scalable/apps
+    mkdir -p {{builddir}}{{PREFIX}}/share/icons/hicolor/scalable/apps
     cp ../{{project_name}}.Shared/Resources/{{app_id}}.svg \
-        {{PREFIX}}/share/icons/hicolor/scalable/apps/
+        {{builddir}}{{PREFIX}}/share/icons/hicolor/scalable/apps/
     cp ../{{project_name}}.Shared/Resources/{{app_id}}-devel.svg \
-        {{PREFIX}}/share/icons/hicolor/scalable/apps/
-    mkdir -p {{PREFIX}}/share/icons/hicolor/symbolic/apps
+        {{builddir}}{{PREFIX}}/share/icons/hicolor/scalable/apps/
+    mkdir -p {{builddir}}{{PREFIX}}/share/icons/hicolor/symbolic/apps
     cp ../{{project_name}}.Shared/Resources/{{app_id}}-symbolic.svg \
-        {{PREFIX}}/share/icons/hicolor/symbolic/apps/
+        {{builddir}}{{PREFIX}}/share/icons/hicolor/symbolic/apps/
 
     # Installing GResource
-    mkdir -p {{PREFIX}}/share/{{app_id}}
+    mkdir -p {{builddir}}{{PREFIX}}/share/{{app_id}}
     glib-compile-resources --sourcedir ./Resources ./Resources/{{app_id}}.gresource.xml
     mv ./Resources/{{app_id}}.gresource \
-        {{PREFIX}}/share/{{app_id}}/
+        {{builddir}}{{PREFIX}}/share/{{app_id}}/
 
     # Installing desktop file
-    mkdir -p {{PREFIX}}/share/applications
-    cp ./{{app_id}}.desktop {{PREFIX}}/share/applications/
+    mkdir -p {{builddir}}{{PREFIX}}/share/applications
+    cp ./{{app_id}}.desktop {{builddir}}{{PREFIX}}/share/applications/
     desktop-file-edit --set-key='Exec' \
     --set-value='{{PREFIX}}/bin/{{app_id}}' \
-    {{PREFIX}}/share/applications/{{app_id}}.desktop
+    {{builddir}}{{PREFIX}}/share/applications/{{app_id}}.desktop
 
     # Installing metainfo
-    mkdir -p {{PREFIX}}/share/metainfo
-    cp ./{{app_id}}.metainfo.xml {{PREFIX}}/share/metainfo/
+    mkdir -p {{builddir}}{{PREFIX}}/share/metainfo
+    cp ./{{app_id}}.metainfo.xml {{builddir}}{{PREFIX}}/share/metainfo/
 
 _translate_meta PREFIX:
     #!/usr/bin/env python3
@@ -177,7 +167,7 @@ _translate_meta PREFIX:
     meta_summaries.sort()
     meta_descriptions.sort()
 
-    with open('{{PREFIX}}/share/applications/{{app_id}}.desktop', 'r') as f:
+    with open('{{builddir}}{{PREFIX}}/share/applications/{{app_id}}.desktop', 'r') as f:
         contents = f.readlines()
         new_contents = contents.copy()
     j = 0
@@ -189,11 +179,11 @@ _translate_meta PREFIX:
             new_contents.insert(j + 1, "\n".join(desktop_keywords) + "\n")
             j += 1
         j += 1
-    with open('{{PREFIX}}/share/applications/{{app_id}}.desktop', 'w') as f:
+    with open('{{builddir}}{{PREFIX}}/share/applications/{{app_id}}.desktop', 'w') as f:
         new_contents = "".join(new_contents)
         f.write(new_contents)
 
-    with open('{{PREFIX}}/share/metainfo/{{app_id}}.metainfo.xml', 'r') as f:
+    with open('{{builddir}}{{PREFIX}}/share/metainfo/{{app_id}}.metainfo.xml', 'r') as f:
         contents = f.readlines()
         new_contents = contents.copy()
     j = 0
@@ -205,7 +195,7 @@ _translate_meta PREFIX:
             new_contents.insert(j + 4, "\n".join(meta_descriptions) + "\n")
             break
         j += 1
-    with open('{{PREFIX}}/share/metainfo/{{app_id}}.metainfo.xml', 'w') as f:
+    with open('{{builddir}}{{PREFIX}}/share/metainfo/{{app_id}}.metainfo.xml', 'w') as f:
         new_contents = "".join(new_contents)
         f.write(new_contents)
     print("Done!")
@@ -215,8 +205,9 @@ generate-flatpak-sources: _generate-flatpak-sources-just _generate-flatpak-sourc
 
 _generate-flatpak-sources-just:
     # Generating sources for just
-    curl "https://raw.githubusercontent.com/casey/just/baa2dfcc6f180d123672544c5ed1aedc32608228/Cargo.lock" -o /tmp/Cargo.lock
-    flatpak-cargo-generator.py -o cargo-sources.json /tmp/Cargo.lock
+    curl "https://raw.githubusercontent.com/casey/just/baa2dfcc6f180d123672544c5ed1aedc32608228/Cargo.lock" -o ./Cargo.lock
+    flatpak-cargo-generator.py -o cargo-sources.json ./Cargo.lock
+    rm ./Cargo.lock
 
 _generate-flatpak-sources-dotnet:
     # Generating sources for dotnet

--- a/NickvisionTubeConverter.Shared/Controllers/MainWindowController.cs
+++ b/NickvisionTubeConverter.Shared/Controllers/MainWindowController.cs
@@ -4,9 +4,6 @@ using NickvisionTubeConverter.Shared.Helpers;
 using NickvisionTubeConverter.Shared.Models;
 using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Runtime.InteropServices;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace NickvisionTubeConverter.Shared.Controllers;
@@ -164,15 +161,6 @@ public class MainWindowController : IDisposable
             Python.Runtime.RuntimeData.FormatterType = typeof(NoopFormatter);
             Python.Runtime.PythonEngine.Initialize();
             _pythonThreadState = Python.Runtime.PythonEngine.BeginAllowThreads();
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                using (Python.Runtime.Py.GIL())
-                {
-                    dynamic sys = Python.Runtime.Py.Import("sys");
-                    var pathToOutput = $"{Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)}{Path.DirectorySeparatorChar}Nickvision{Path.DirectorySeparatorChar}{AppInfo.Current.Name}{Path.DirectorySeparatorChar}output.txt";
-                    sys.stdout = Python.Runtime.PythonEngine.Eval($"open(\"{Regex.Replace(pathToOutput, @"\\", @"\\")}\", \"w\")");
-                }
-            }
         }
     }
 
@@ -244,7 +232,7 @@ public class MainWindowController : IDisposable
     /// <param name="row">The stopped row</param>
     private void DownloadStopped(IDownloadRowControl row)
     {
-        if(_queuedRows.Contains(row))
+        if (_queuedRows.Contains(row))
         {
             _queuedRows.Remove(row);
             UIDeleteDownloadRowFromQueue!(row);

--- a/NickvisionTubeConverter.Shared/Controllers/MainWindowController.cs
+++ b/NickvisionTubeConverter.Shared/Controllers/MainWindowController.cs
@@ -4,6 +4,7 @@ using NickvisionTubeConverter.Shared.Helpers;
 using NickvisionTubeConverter.Shared.Models;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Threading.Tasks;
 
 namespace NickvisionTubeConverter.Shared.Controllers;
@@ -121,7 +122,7 @@ public class MainWindowController : IDisposable
     }
 
     /// <summary>
-    /// Frees resources used by the Account object
+    /// Frees resources used by the MainWindowController object
     /// </summary>
     public void Dispose()
     {
@@ -130,7 +131,7 @@ public class MainWindowController : IDisposable
     }
 
     /// <summary>
-    /// Frees resources used by the Account object
+    /// Frees resources used by the MainWindowController object
     /// </summary>
     protected virtual void Dispose(bool disposing)
     {
@@ -140,9 +141,26 @@ public class MainWindowController : IDisposable
         }
         if (disposing)
         {
+            var pathToOutput = $"{Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)}{Path.DirectorySeparatorChar}Nickvision{Path.DirectorySeparatorChar}{AppInfo.Current.Name}{Path.DirectorySeparatorChar}output.log";
             Localizer.Dispose();
             Python.Runtime.PythonEngine.EndAllowThreads(_pythonThreadState);
             Python.Runtime.PythonEngine.Shutdown();
+            if (File.Exists(pathToOutput))
+            {
+                File.Delete(pathToOutput);
+            }
+            foreach (var row in _downloadingRows)
+            {
+                row.Dispose();
+            }
+            foreach (var row in _completedRows)
+            {
+                row.Dispose();
+            }
+            foreach (var row in _queuedRows)
+            {
+                row.Dispose();
+            }
         }
         _disposed = true;
     }
@@ -200,6 +218,10 @@ public class MainWindowController : IDisposable
     public void StopAllDownloads()
     {
         foreach (var row in _downloadingRows)
+        {
+            row.Stop();
+        }
+        foreach (var row in _queuedRows)
         {
             row.Stop();
         }

--- a/NickvisionTubeConverter.Shared/Controllers/MainWindowController.cs
+++ b/NickvisionTubeConverter.Shared/Controllers/MainWindowController.cs
@@ -96,27 +96,15 @@ public class MainWindowController : IDisposable
     {
         get
         {
-            var timeNowHours = DateTime.Now.Hour;
-            if (timeNowHours >= 0 && timeNowHours < 6)
+            var greeting = DateTime.Now.Hour switch
             {
-                return Localizer["Greeting", "Night"];
-            }
-            else if (timeNowHours >= 6 && timeNowHours < 12)
-            {
-                return Localizer["Greeting", "Morning"];
-            }
-            else if (timeNowHours >= 12 && timeNowHours < 18)
-            {
-                return Localizer["Greeting", "Afternoon"];
-            }
-            else if (timeNowHours >= 18 && timeNowHours < 24)
-            {
-                return Localizer["Greeting", "Evening"];
-            }
-            else
-            {
-                return Localizer["Greeting", "Generic"];
-            }
+                >= 0 and < 6 => "Night",
+                < 12 => "Morning",
+                < 18 => "Afternoon",
+                < 24 => "Evening",
+                _ => "Generic"
+            };
+            return Localizer["Greeting", greeting];
         }
     }
 

--- a/NickvisionTubeConverter.Shared/Controls/IDownloadRowControl.cs
+++ b/NickvisionTubeConverter.Shared/Controls/IDownloadRowControl.cs
@@ -6,7 +6,7 @@ namespace NickvisionTubeConverter.Shared.Controls;
 /// <summary>
 /// A contract for a download row control
 /// </summary>
-public interface IDownloadRowControl
+public interface IDownloadRowControl : IDisposable
 {
     /// <summary>
     /// Whether or not the download is done

--- a/NickvisionTubeConverter.Shared/Controls/IDownloadRowControl.cs
+++ b/NickvisionTubeConverter.Shared/Controls/IDownloadRowControl.cs
@@ -26,10 +26,10 @@ public interface IDownloadRowControl : IDisposable
     public Func<IDownloadRowControl, Task>? DownloadRetriedAsyncCallback { get; set; }
 
     /// <summary>
-    /// Starts the download
+    /// Runs the download
     /// </summary>
     /// <param name="embedMetadata">Whether or not to embed video metadata</param>
-    public Task StartAsync(bool embedMetadata);
+    public Task RunAsync(bool embedMetadata);
 
     /// <summary>
     /// Stops the download

--- a/NickvisionTubeConverter.Shared/Helpers/PythonExtensions.cs
+++ b/NickvisionTubeConverter.Shared/Helpers/PythonExtensions.cs
@@ -19,6 +19,7 @@ public static class PythonExtensions
             dynamic sys = Python.Runtime.Py.Import("sys");
             dynamic file = Python.Runtime.PythonEngine.Eval($"open(\"{Regex.Replace(path, @"\\", @"\\")}\", \"w\")");
             sys.stdout = file;
+            sys.stderr = file;
             return file;
         }
     }

--- a/NickvisionTubeConverter.Shared/Helpers/PythonExtensions.cs
+++ b/NickvisionTubeConverter.Shared/Helpers/PythonExtensions.cs
@@ -1,0 +1,15 @@
+﻿using System.Text.RegularExpressions;
+
+namespace NickvisionTubeConverter.Shared.Helpers;
+
+public static class PythonExtensions
+{
+    public static void SetConsoleOutputFilePath(string path)
+    {
+        using (Python.Runtime.Py.GIL())
+        {
+            dynamic sys = Python.Runtime.Py.Import("sys");
+            sys.stdout = Python.Runtime.PythonEngine.Eval($"open(\"{Regex.Replace(path, @"\\", @"\\")}\", \"w\")");
+        }
+    }
+}

--- a/NickvisionTubeConverter.Shared/Helpers/PythonExtensions.cs
+++ b/NickvisionTubeConverter.Shared/Helpers/PythonExtensions.cs
@@ -2,14 +2,24 @@
 
 namespace NickvisionTubeConverter.Shared.Helpers;
 
+/// <summary>
+/// Extension methods for python engine
+/// </summary>
 public static class PythonExtensions
 {
-    public static void SetConsoleOutputFilePath(string path)
+    /// <summary>
+    /// Sets the console output of python to a file
+    /// </summary>
+    /// <param name="path">The path of the file</param>
+    /// <returns>The file handle object</returns>
+    public static dynamic SetConsoleOutputFilePath(string path)
     {
         using (Python.Runtime.Py.GIL())
         {
             dynamic sys = Python.Runtime.Py.Import("sys");
-            sys.stdout = Python.Runtime.PythonEngine.Eval($"open(\"{Regex.Replace(path, @"\\", @"\\")}\", \"w\")");
+            dynamic file = Python.Runtime.PythonEngine.Eval($"open(\"{Regex.Replace(path, @"\\", @"\\")}\", \"w\")");
+            sys.stdout = file;
+            return file;
         }
     }
 }

--- a/NickvisionTubeConverter.Shared/Models/Download.cs
+++ b/NickvisionTubeConverter.Shared/Models/Download.cs
@@ -274,7 +274,7 @@ public class Download
                 };
                 using var fs = new FileStream(_logPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
                 using var sr = new StreamReader(fs);
-                progressState.Log = sr.ReadToEnd();
+                progressState.Log = sr.ReadToEnd().Remove(0, 1);
                 sr.Close();
                 fs.Close();
                 _progressCallback(progressState);

--- a/NickvisionTubeConverter.Shared/Models/Download.cs
+++ b/NickvisionTubeConverter.Shared/Models/Download.cs
@@ -309,11 +309,14 @@ public class Download : IDisposable
                     Progress = downloaded / total,
                     Speed = entries.HasKey("speed") ? (entries["speed"].As<double?>() ?? 0) / 1024f : 0
                 };
-                using var fs = new FileStream(_logPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-                using var sr = new StreamReader(fs);
-                progressState.Log = sr.ReadToEnd().Remove(0, 1);
-                sr.Close();
-                fs.Close();
+                if (File.Exists(_logPath))
+                {
+                    using var fs = new FileStream(_logPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                    using var sr = new StreamReader(fs);
+                    progressState.Log = sr.ReadToEnd().Remove(0, 1);
+                    sr.Close();
+                    fs.Close();
+                }
                 _progressCallback(progressState);
             }
 

--- a/NickvisionTubeConverter.Shared/Models/Download.cs
+++ b/NickvisionTubeConverter.Shared/Models/Download.cs
@@ -194,7 +194,7 @@ public class Download : IDisposable
                 var hooks = new List<Action<Python.Runtime.PyDict>> { };
                 hooks.Add(ProgressHook);
                 var ytOpt = new Dictionary<string, dynamic> {
-                        { "quiet", true },
+                        { "quiet", false },
                         { "ignoreerrors", "downloadonly" },
                         { "merge_output_format", "mp4/webm/mp3/opus/flac/wav" },
                         { "final_ext", _fileType.ToString().ToLower() },

--- a/NickvisionTubeConverter.Shared/Models/Download.cs
+++ b/NickvisionTubeConverter.Shared/Models/Download.cs
@@ -41,8 +41,9 @@ public enum DownloadStage
 /// <summary>
 /// A model of a video download
 /// </summary>
-public class Download
+public class Download : IDisposable
 {
+    private bool _disposed;
     private readonly Guid _id;
     private readonly MediaFileType _fileType;
     private readonly Quality _quality;
@@ -79,6 +80,7 @@ public class Download
     /// <param name="subtitle">The subtitles for the download</param>
     public Download(string videoUrl, MediaFileType fileType, string saveFolder, string saveFilename, Quality quality = Quality.Best, Subtitle subtitle = Subtitle.None)
     {
+        _disposed = false;
         _id = Guid.NewGuid();
         _fileType = fileType;
         _quality = quality;
@@ -90,6 +92,34 @@ public class Download
         SaveFolder = saveFolder;
         Filename = saveFilename;
         IsDone = false;
+    }
+
+    /// <summary>
+    /// Frees resources used by the Download object
+    /// </summary>
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Frees resources used by the Download object
+    /// </summary>
+    protected virtual void Dispose(bool disposing)
+    {
+        if (_disposed)
+        {
+            return;
+        }
+        if (disposing)
+        {
+            if (File.Exists(_logPath))
+            {
+                File.Delete(_logPath);
+            }
+        }
+        _disposed = true;
     }
 
     /// <summary>

--- a/NickvisionTubeConverter.Shared/Models/DownloadProgressState.cs
+++ b/NickvisionTubeConverter.Shared/Models/DownloadProgressState.cs
@@ -27,6 +27,10 @@ public class DownloadProgressState
     /// The speed of the download
     /// </summary>
     public double Speed { get; set; }
+    /// <summary>
+    /// The current log of the download
+    /// </summary>
+    public string Log { get; set; }
 
     /// <summary>
     /// Constructs a DownloadProgressState
@@ -36,5 +40,6 @@ public class DownloadProgressState
         Status = DownloadProgressStatus.Processing;
         Progress = 0.0;
         Speed = 0.0;
+        Log = "";
     }
 }

--- a/NickvisionTubeConverter.Shared/Resources/Strings.resx
+++ b/NickvisionTubeConverter.Shared/Resources/Strings.resx
@@ -248,7 +248,7 @@
 	<data name="ViewLog" xml:space="preserve">
 		<value>View Log</value>
 	</data>
-		
+
 	<data name="StopDownload" xml:space="preserve">
 		<value>Stop Download</value>
 	</data>
@@ -259,6 +259,14 @@
 
 	<data name="RetryDownload" xml:space="preserve">
 		<value>Retry Download</value>
+	</data>
+
+	<data name="CopyToClipboard" xml:space="preserve">
+		<value>Copy to Clipboard</value>
+	</data>
+
+	<data name="LogCopied" xml:space="preserve">
+		<value>Download log was copied to clipboard</value>
 	</data>
 
 	<data name="Success" xml:space="preserve">

--- a/NickvisionTubeConverter.Shared/Resources/Strings.resx
+++ b/NickvisionTubeConverter.Shared/Resources/Strings.resx
@@ -245,6 +245,10 @@
 		<value>Downloading {0:f2}% ({1:N0} KiB/s)</value>
 	</data>
 
+	<data name="ViewLog" xml:space="preserve">
+		<value>View Log</value>
+	</data>
+		
 	<data name="StopDownload" xml:space="preserve">
 		<value>Stop Download</value>
 	</data>

--- a/NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml
+++ b/NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml
@@ -11,36 +11,50 @@
     mc:Ignorable="d">
 
     <Border Margin="0,6,0,0" Background="{ThemeResource CardBackgroundFillColorDefaultBrush}" BorderThickness="1" BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}" CornerRadius="8">
-        <wct:DockPanel Margin="10,4,10,4" LastChildFill="True">
-            <FontIcon x:Name="Icon" wct:DockPanel.Dock="Left" VerticalAlignment="Center" FontFamily="{StaticResource SymbolThemeFontFamily}"/>
+        <StackPanel Margin="10,4,10,4" Orientation="Vertical" Spacing="12">
+            <wct:DockPanel LastChildFill="True">
+                <FontIcon x:Name="Icon" wct:DockPanel.Dock="Left" VerticalAlignment="Center" FontFamily="{StaticResource SymbolThemeFontFamily}"/>
 
-            <Button x:Name="BtnStop" wct:DockPanel.Dock="Right" VerticalAlignment="Center" Visibility="Collapsed" Click="BtnStop_Click">
-                <Button.Content>
-                    <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE15B;"/>
-                </Button.Content>
-            </Button>
+                <ToggleButton x:Name="BtnViewLog" wct:DockPanel.Dock="Right" VerticalAlignment="Center" Click="BtnViewLog_Click">
+                    <ToggleButton.Content>
+                        <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xEA80;"/>
+                    </ToggleButton.Content>
+                </ToggleButton>
+                
+                <Button x:Name="BtnStop" wct:DockPanel.Dock="Right" VerticalAlignment="Center" Visibility="Collapsed" Click="BtnStop_Click">
+                    <Button.Content>
+                        <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE15B;"/>
+                    </Button.Content>
+                </Button>
 
-            <Button x:Name="BtnRetry" wct:DockPanel.Dock="Right" VerticalAlignment="Center" Visibility="Collapsed" Click="BtnRetry_Click">
-                <Button.Content>
-                    <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE149;"/>
-                </Button.Content>
-            </Button>
+                <Button x:Name="BtnRetry" wct:DockPanel.Dock="Right" VerticalAlignment="Center" Visibility="Collapsed" Click="BtnRetry_Click">
+                    <Button.Content>
+                        <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE149;"/>
+                    </Button.Content>
+                </Button>
 
-            <Button x:Name="BtnOpenSaveFolder" wct:DockPanel.Dock="Right" VerticalAlignment="Center" Visibility="Collapsed" Click="BtnOpenSaveFolder_Click">
-                <Button.Content>
-                    <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE838;"/>
-                </Button.Content>
-            </Button>
+                <Button x:Name="BtnOpenSaveFolder" wct:DockPanel.Dock="Right" VerticalAlignment="Center" Visibility="Collapsed" Click="BtnOpenSaveFolder_Click">
+                    <Button.Content>
+                        <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE838;"/>
+                    </Button.Content>
+                </Button>
 
-            <StackPanel wct:DockPanel.Dock="Left" Margin="10,0,10,0" Orientation="Vertical" Spacing="2">
-                <TextBlock x:Name="LblFilename"/>
+                <StackPanel wct:DockPanel.Dock="Left" Margin="10,0,10,0" Orientation="Vertical" Spacing="2">
+                    <TextBlock x:Name="LblFilename"/>
 
-                <TextBlock x:Name="LblUrl" Foreground="Gray"/>
+                    <TextBlock x:Name="LblUrl" Foreground="Gray"/>
 
-                <ProgressBar x:Name="ProgBar" HorizontalAlignment="Stretch" Height="10" Minimum="0" Maximum="1"/>
+                    <ProgressBar x:Name="ProgBar" HorizontalAlignment="Stretch" Height="10" Minimum="0" Maximum="1"/>
 
-                <TextBlock x:Name="LblStatus"/>
-            </StackPanel>
-        </wct:DockPanel>
+                    <TextBlock x:Name="LblStatus"/>
+                </StackPanel>
+            </wct:DockPanel>
+
+            <Border x:Name="SectionLog" Visibility="Collapsed" Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}" BorderThickness="1" BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}" CornerRadius="8">
+                <ScrollViewer MaxHeight="300">
+                    <TextBlock x:Name="LblLog" Margin="6,6,6,6" TextWrapping="Wrap"/>
+                </ScrollViewer>
+            </Border>
+        </StackPanel>
     </Border>
 </UserControl>

--- a/NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml
+++ b/NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml
@@ -51,7 +51,7 @@
             </wct:DockPanel>
 
             <Border x:Name="SectionLog" Visibility="Collapsed" Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}" BorderThickness="1" BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}" CornerRadius="8">
-                <ScrollViewer x:Name="ScrollLog" MaxHeight="200">
+                <ScrollViewer x:Name="ScrollLog" MaxHeight="100">
                     <TextBlock x:Name="LblLog" Margin="6,6,6,6" TextWrapping="Wrap"/>
                 </ScrollViewer>
             </Border>

--- a/NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml
+++ b/NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml
@@ -15,12 +15,6 @@
             <wct:DockPanel LastChildFill="True">
                 <FontIcon x:Name="Icon" wct:DockPanel.Dock="Left" VerticalAlignment="Center" FontFamily="{StaticResource SymbolThemeFontFamily}"/>
 
-                <ToggleButton x:Name="BtnViewLog" wct:DockPanel.Dock="Right" VerticalAlignment="Center" Click="BtnViewLog_Click">
-                    <ToggleButton.Content>
-                        <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xEA80;"/>
-                    </ToggleButton.Content>
-                </ToggleButton>
-                
                 <Button x:Name="BtnStop" wct:DockPanel.Dock="Right" VerticalAlignment="Center" Visibility="Collapsed" Click="BtnStop_Click">
                     <Button.Content>
                         <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE15B;"/>
@@ -39,8 +33,14 @@
                     </Button.Content>
                 </Button>
 
+                <ToggleButton x:Name="BtnViewLog" wct:DockPanel.Dock="Right" VerticalAlignment="Center" Margin="0,0,6,0" Click="BtnViewLog_Click">
+                    <ToggleButton.Content>
+                        <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xEA80;"/>
+                    </ToggleButton.Content>
+                </ToggleButton>
+
                 <StackPanel wct:DockPanel.Dock="Left" Margin="10,0,10,0" Orientation="Vertical" Spacing="2">
-                    <TextBlock x:Name="LblFilename"/>
+                    <TextBlock x:Name="LblFilename" TextWrapping="Wrap"/>
 
                     <TextBlock x:Name="LblUrl" Foreground="Gray"/>
 
@@ -51,7 +51,7 @@
             </wct:DockPanel>
 
             <Border x:Name="SectionLog" Visibility="Collapsed" Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}" BorderThickness="1" BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}" CornerRadius="8">
-                <ScrollViewer MaxHeight="300">
+                <ScrollViewer x:Name="ScrollLog" MaxHeight="200">
                     <TextBlock x:Name="LblLog" Margin="6,6,6,6" TextWrapping="Wrap"/>
                 </ScrollViewer>
             </Border>

--- a/NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml
+++ b/NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml
@@ -52,7 +52,7 @@
 
             <Border x:Name="SectionLog" Visibility="Collapsed" Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}" BorderThickness="1" BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}" CornerRadius="8">
                 <ScrollViewer x:Name="ScrollLog" MaxHeight="100">
-                    <TextBlock x:Name="LblLog" Margin="6,6,6,6" TextWrapping="Wrap"/>
+                    <TextBlock x:Name="LblLog" Margin="6,6,6,6" IsTextSelectionEnabled="True" TextWrapping="Wrap"/>
                 </ScrollViewer>
             </Border>
         </StackPanel>

--- a/NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs
+++ b/NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs
@@ -58,6 +58,7 @@ public sealed partial class DownloadRow : UserControl, IDownloadRowControl
         BtnOpenSaveFolder.Visibility = Visibility.Collapsed;
         ProgBar.Value = 0;
         //Localize Strings
+        ToolTipService.SetToolTip(BtnViewLog, _localizer["ViewLog"]);
         ToolTipService.SetToolTip(BtnStop, _localizer["StopDownload"]);
         ToolTipService.SetToolTip(BtnRetry, _localizer["RetryDownload"]);
         ToolTipService.SetToolTip(BtnOpenSaveFolder, _localizer["OpenSaveFolder"]);
@@ -85,6 +86,10 @@ public sealed partial class DownloadRow : UserControl, IDownloadRowControl
         ProgBar.Value = 0;
         var success = await _download.RunAsync(embedMetadata, (state) =>
         {
+            App.MainWindow!.DispatcherQueue.TryEnqueue(() =>
+            {
+                LblLog.Text = state.Log;
+            });
             switch (state.Status)
             {
                 case DownloadProgressStatus.Downloading:
@@ -139,6 +144,13 @@ public sealed partial class DownloadRow : UserControl, IDownloadRowControl
             DownloadStoppedCallback(this);
         }
     }
+
+    /// <summary>
+    /// Occurs when the view log button is clicked
+    /// </summary>
+    /// <param name="sender">object</param>
+    /// <param name="e">RoutedEventArgs</param>
+    private void BtnViewLog_Click(object sender, RoutedEventArgs e) => SectionLog.Visibility = BtnViewLog.IsChecked ?? false ? Visibility.Visible : Visibility.Collapsed;
 
     /// <summary>
     /// Occurs when the stop button is clicked

--- a/NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs
+++ b/NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs
@@ -14,6 +14,7 @@ namespace NickvisionTubeConverter.WinUI.Controls;
 /// </summary>
 public sealed partial class DownloadRow : UserControl, IDownloadRowControl
 {
+    private bool _disposed;
     private readonly Localizer _localizer;
     private readonly Download _download;
     private bool? _previousEmbedMetadata;
@@ -45,6 +46,7 @@ public sealed partial class DownloadRow : UserControl, IDownloadRowControl
     public DownloadRow(Localizer localizer, Download download)
     {
         InitializeComponent();
+        _disposed = false;
         _localizer = localizer;
         _download = download;
         _previousEmbedMetadata = null;
@@ -64,6 +66,31 @@ public sealed partial class DownloadRow : UserControl, IDownloadRowControl
         ToolTipService.SetToolTip(BtnOpenSaveFolder, _localizer["OpenSaveFolder"]);
         //Load
         LblUrl.Text = _download.VideoUrl;
+    }
+
+    /// <summary>
+    /// Frees resources used by the DownloadRow object
+    /// </summary>
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Frees resources used by the DownloadRow object
+    /// </summary>
+    private void Dispose(bool disposing)
+    {
+        if (_disposed)
+        {
+            return;
+        }
+        if (disposing)
+        {
+            _download.Dispose();
+        }
+        _disposed = true;
     }
 
     /// <summary>

--- a/NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs
+++ b/NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs
@@ -94,10 +94,10 @@ public sealed partial class DownloadRow : UserControl, IDownloadRowControl
     }
 
     /// <summary>
-    /// Starts the download
+    /// Runs the download
     /// </summary>
     /// <param name="embedMetadata">Whether or not to embed video metadata</param>
-    public async Task StartAsync(bool embedMetadata)
+    public async Task RunAsync(bool embedMetadata)
     {
         if (_previousEmbedMetadata == null)
         {

--- a/NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs
+++ b/NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs
@@ -89,6 +89,8 @@ public sealed partial class DownloadRow : UserControl, IDownloadRowControl
             App.MainWindow!.DispatcherQueue.TryEnqueue(() =>
             {
                 LblLog.Text = state.Log;
+                ScrollLog.UpdateLayout();
+                ScrollLog.ScrollToVerticalOffset(ScrollLog.ScrollableHeight);
             });
             switch (state.Status)
             {

--- a/NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs
+++ b/NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs
@@ -51,7 +51,7 @@ public sealed partial class AddDownloadDialog : ContentDialog
         CmbSubtitle.Items.Add("SRT");
         CmbSubtitle.SelectedIndex = 0;
         TxtSavePath.Header = _controller.Localizer["SavePath", "Field"];
-        ToolTipService.SetToolTip(BtnSelectSavePath, _controller.Localizer["SelectSaveFolder"]);
+        ToolTipService.SetToolTip(BtnSelectSavePath, _controller.Localizer["SelectSavePath"]);
         TxtErrors.Text = _controller.Localizer["FixErrors", "WinUI"];
         //Load
         ViewStack.ChangePage("Download");


### PR DESCRIPTION
This PR implements the ability to view logs of a download as it is occurring.

Closes #40 

![image](https://user-images.githubusercontent.com/17648453/222037080-fb7803b2-a288-4998-a8fd-aad932f41cf5.png)
![image](https://user-images.githubusercontent.com/17648453/222153258-27c50b40-7b59-4f53-bd0a-1af7dfdddfe9.png)

## Todo
- [X] Delete log files when the application is closed
- [x] Fix GNOME scrolling to the end of the logs section (currently it scrolls to the last log - 1)
- [ ] **NOT BLOCKING** -- Wait for `yt-dlp` to release the slowness fix (https://github.com/yt-dlp/yt-dlp/issues/6369#issuecomment-1450068901)
- [x] Start more downloads in the queue if `Max Number of Active Downloads` increased