### PR TITLE
GNOME - Further clean up MoveDownloadRow method

### DIFF
--- a/NickvisionTubeConverter.GNOME/Blueprints/window.blp
+++ b/NickvisionTubeConverter.GNOME/Blueprints/window.blp
@@ -119,7 +119,7 @@ Adw.ApplicationWindow _root {
                   valign: start;
                       
 
-                  Gtk.Box _sectionDownloading {
+                  Gtk.Box {
                     orientation: vertical;
                     spacing: 10;
                     visible: false;
@@ -139,7 +139,7 @@ Adw.ApplicationWindow _root {
                     }
                   }
 
-                  Gtk.Box _sectionCompleted {
+                  Gtk.Box {
                     orientation: vertical;
                     spacing: 10;
                     visible: false;
@@ -159,7 +159,7 @@ Adw.ApplicationWindow _root {
                     }
                   }
 
-                  Gtk.Box _sectionQueued {
+                  Gtk.Box {
                     orientation: vertical;
                     spacing: 10;
                     visible: false;


### PR DESCRIPTION
Also fixes GTK errors on trying to remove a download row widget from a Gtk.Box it is not a child of.