### PR TITLE
Release fixes

### DIFF
--- a/NickvisionTubeConverter.GNOME/Program.cs
+++ b/NickvisionTubeConverter.GNOME/Program.cs
@@ -29,7 +29,7 @@ public partial class Program
     /// </summary>
     /// <param name="args">string[]</param>
     /// <returns>Return code from Adw.Application.Run()</returns>
-    public static int Main(string[] args) => new Program().Run();
+    public static int Main(string[] args) => new Program().Run(args);
 
     /// <summary>
     /// Constructs a Program
@@ -76,11 +76,14 @@ public partial class Program
     /// Runs the program
     /// </summary>
     /// <returns>Return code from Adw.Application.Run()</returns>
-    public int Run()
+    public int Run(string[] args)
     {
         try
         {
-            return _application.Run();
+            var argv = new string[args.Length + 1];
+            argv[0] = "NickvisionTubeConverter.GNOME";
+            args.CopyTo(argv, 1);
+            return _application.Run(args.Length + 1, argv);
         }
         catch (Exception ex)
         {

--- a/NickvisionTubeConverter.GNOME/org.nickvision.tubeconverter.json
+++ b/NickvisionTubeConverter.GNOME/org.nickvision.tubeconverter.json
@@ -24,8 +24,7 @@
         "--share=network",
         "--filesystem=xdg-videos",
         "--filesystem=xdg-music",
-        "--filesystem=xdg-download",
-        "--filesystem=~/.tc-temp"
+        "--filesystem=xdg-download"
     ],
     "cleanup": [
       "/include",

--- a/NickvisionTubeConverter.GNOME/org.nickvision.tubeconverter.json
+++ b/NickvisionTubeConverter.GNOME/org.nickvision.tubeconverter.json
@@ -24,7 +24,8 @@
         "--share=network",
         "--filesystem=xdg-videos",
         "--filesystem=xdg-music",
-        "--filesystem=xdg-download"
+        "--filesystem=xdg-download",
+        "--filesystem=~/.tc-temp"
     ],
     "cleanup": [
       "/include",

--- a/NickvisionTubeConverter.Shared/Models/Configuration.cs
+++ b/NickvisionTubeConverter.Shared/Models/Configuration.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Text.Json;
 
 namespace NickvisionTubeConverter.Shared.Models;
@@ -16,7 +17,20 @@ public class Configuration
     /// <summary>
     /// The directory to store temporary files
     /// </summary>
-    public static readonly string TempDir = $"{Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)}{Path.DirectorySeparatorChar}.tc-temp";
+    public static string TempDir
+    {
+        get
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return $"{Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)}{Path.DirectorySeparatorChar}.tc-temp";
+            }
+            else
+            {
+                return $"{ConfigDir}{Path.DirectorySeparatorChar}temp";
+            }
+        }
+    }
 
     private static readonly string ConfigPath = $"{ConfigDir}{Path.DirectorySeparatorChar}config.json";
     private static Configuration? _instance;

--- a/NickvisionTubeConverter.Shared/Models/Download.cs
+++ b/NickvisionTubeConverter.Shared/Models/Download.cs
@@ -231,7 +231,15 @@ public class Download
             using (Python.Runtime.Py.GIL())
             {
                 var downloaded = entries.HasKey("downloaded_bytes") ? (entries["downloaded_bytes"].As<double?>() ?? 0) : 0;
-                var total = entries.HasKey("total_bytes") ? (entries["total_bytes"].As<double?>() ?? 1) : downloaded;
+                var total = 1.0;
+                if (entries.HasKey("total_bytes"))
+                {
+                    total = entries["total_bytes"].As<double?>() ?? 1;
+                }
+                else if (entries.HasKey("total_bytes_estimate"))
+                {
+                    total = entries["total_bytes_estimate"].As<double?>() ?? 1;
+                }
                 var progressState = new DownloadProgressState()
                 {
                     Status = entries["status"].As<string>() switch

--- a/NickvisionTubeConverter.Shared/Models/VideoUrlInfo.cs
+++ b/NickvisionTubeConverter.Shared/Models/VideoUrlInfo.cs
@@ -112,7 +112,7 @@ public class VideoUrlInfo
     /// <returns>A VideoUrlInfo object. Null if url invalid</returns>
     public static async Task<VideoUrlInfo?> GetAsync(string url)
     {
-        var pathToOutput = $"{Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)}{Path.DirectorySeparatorChar}.tc-temp{Path.DirectorySeparatorChar}output.log";
+        var pathToOutput = $"{Configuration.TempDir}{Path.DirectorySeparatorChar}output.log";
         dynamic outFile = PythonExtensions.SetConsoleOutputFilePath(pathToOutput);
         return await Task.Run(() =>
         {


### PR DESCRIPTION
1. Fixed the problem when the app was starting with 2 windows open and dependency error notification. The cause of problem was that we now have dbus service that starts the app with `--gapplication-service` flag, but the app wasn't able to pass it to `Gio.Application` thus opening second window that, being started by dbus and as result isolated somehow, wasn't able to init python properly. I'm going to bring this changes to Application together with dbus service so we don't worry about it for any app anymore.
2. Set temp dir to be inside config dir on Linux
3. Properly show download progress with unknown total size by using estimated size (I thought I fixed it, but I guess I did changes some night locally and forgot that I didn't commit that 😅 )