### PR TITLE
GNOME - Snap fix

### DIFF
--- a/NickvisionTubeConverter.GNOME/justfile
+++ b/NickvisionTubeConverter.GNOME/justfile
@@ -103,7 +103,7 @@ clean:
 publish-flatpak: (publish-self-contained "/app") install
 
 # Command to be used in snap YAML
-install-snap PREFIX="/usr":
+install-snap PREFIX="/snap/tube-converter/current/usr":
     @set +u; [ -n "$TC_PYTHON_SO" ] || (echo "Environment variable TC_PYTHON_SO is not set, aborting."; exit 1)
     just install /root/prime/
     sed -i "2 i export TC_PYTHON_SO=$TC_PYTHON_SO" /root/prime{{PREFIX}}/bin/{{app_id}}

--- a/NickvisionTubeConverter.GNOME/justfile
+++ b/NickvisionTubeConverter.GNOME/justfile
@@ -102,6 +102,12 @@ clean:
 # Command to be used in flatpak manifest
 publish-flatpak: (publish-self-contained "/app") install
 
+# Command to be used in snap YAML
+install-snap PREFIX="/usr":
+    @set +u; [ -n "$TC_PYTHON_SO" ] || (echo "Environment variable TC_PYTHON_SO is not set, aborting."; exit 1)
+    just install /root/prime/
+    sed -i "2 i export TC_PYTHON_SO=$TC_PYTHON_SO" /root/prime{{PREFIX}}/bin/{{app_id}}
+
 _install_extras PREFIX: && (_translate_meta PREFIX)
     # Installing icons
     mkdir -p {{builddir}}{{PREFIX}}/share/icons/hicolor/scalable/apps

--- a/NickvisionTubeConverter.Shared/Helpers/DependencyManager.cs
+++ b/NickvisionTubeConverter.Shared/Helpers/DependencyManager.cs
@@ -81,6 +81,10 @@ internal static class DependencyManager
                     Configuration.Current.Save();
                 }
             }
+            else if (File.Exists(Environment.GetEnvironmentVariable("TC_PYTHON_SO")))
+            {
+                Python.Runtime.Runtime.PythonDLL = Environment.GetEnvironmentVariable("TC_PYTHON_SO");
+            }
             else
             {
                 var process = new Process

--- a/NickvisionTubeConverter.Shared/Models/VideoUrlInfo.cs
+++ b/NickvisionTubeConverter.Shared/Models/VideoUrlInfo.cs
@@ -1,4 +1,5 @@
 ﻿using NickvisionTubeConverter.Shared.Helpers;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
@@ -143,8 +144,9 @@ public class VideoUrlInfo
                 }
                 return videoUrlInfo;
             }
-            catch
+            catch (Exception e)
             {
+                Console.WriteLine(e);
                 using (Python.Runtime.Py.GIL())
                 {
                     outFile.close();


### PR DESCRIPTION
This PR adds workaround to let TC find python `.so` in snap. For this, `TC_PYTHON_SO` is used.

Some notes:
* By default `just` runs command with `set -u` which makes sh exit with an error when unset variable is used. But the output os not very helpful, so I implemented kinda "try-catch" by setting `set +u` and then manually checking if the var is empty.
* It's not for snap only really, if some other package manager will require to use some weird path to python `.so` this var can be used because the app looks for it first and only then uses python to find path if needed.

@soumyaDghosh Please try to build snap with the code from this branch to check that it works and then it we'll be merged.
In YAML file:
```
override-prime: |
      craftctl default
      cd /root/parts/tube-converter/build/NickvisionTubeConverter.GNOME
      TC_PYTHON_SO=/path/to/python/file.so just install-snap
```
Also, I already mentioned it but I will repeat: `dotnet-sdk` is only needed for building and `dotnet-runtime` is not needed too if you use `just publish-self-contained`.