### PR TITLE
Set icon for every window

### DIFF
--- a/NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs
+++ b/NickvisionTubeConverter.GNOME/Views/AddDownloadDialog.cs
@@ -85,6 +85,7 @@ public partial class AddDownloadDialog : Adw.MessageDialog
         _videoRows = new List<VideoRow>();
         //Dialog Settings
         SetTransientFor(parent);
+        SetIconName(_controller.AppInfo.ID);
         AddResponse("cancel", controller.Localizer["Cancel"]);
         SetCloseResponse("cancel");
         AddResponse("ok", controller.Localizer["Download"]);

--- a/NickvisionTubeConverter.GNOME/Views/MainWindow.cs
+++ b/NickvisionTubeConverter.GNOME/Views/MainWindow.cs
@@ -33,6 +33,7 @@ public partial class MainWindow : Adw.ApplicationWindow
         _controller = controller;
         _application = application;
         SetTitle(_controller.AppInfo.ShortName);
+        SetIconName(_controller.AppInfo.ID);
         if (_controller.IsDevVersion)
         {
             AddCssClass("devel");
@@ -266,6 +267,7 @@ public partial class MainWindow : Adw.ApplicationWindow
         var builder = Builder.FromFile("shortcuts_dialog.ui", _controller.Localizer, (s) => s == "About" ? string.Format(_controller.Localizer[s], _controller.AppInfo.ShortName) : _controller.Localizer[s]);
         var shortcutsWindow = (Gtk.ShortcutsWindow)builder.GetObject("_shortcuts");
         shortcutsWindow.SetTransientFor(this);
+        shortcutsWindow.SetIconName(_controller.AppInfo.ID);
         shortcutsWindow.Show();
     }
 
@@ -291,6 +293,7 @@ public partial class MainWindow : Adw.ApplicationWindow
     {
         var dialog = Adw.AboutWindow.New();
         dialog.SetTransientFor(this);
+        dialog.SetIconName(_controller.AppInfo.ID);
         dialog.SetApplicationName(_controller.AppInfo.ShortName);
         dialog.SetApplicationIcon(_controller.AppInfo.ID + (_controller.AppInfo.GetIsDevelVersion() ? "-devel" : ""));
         dialog.SetVersion(_controller.AppInfo.Version);

--- a/NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs
+++ b/NickvisionTubeConverter.GNOME/Views/PreferencesDialog.cs
@@ -23,6 +23,7 @@ public partial class PreferencesDialog : Adw.PreferencesWindow
         _controller = controller;
         _application = application;
         SetTransientFor(parent);
+        SetIconName(_controller.AppInfo.ID);
         //Build UI
         builder.Connect(this);
         //Theme

--- a/NickvisionTubeConverter.GNOME/justfile
+++ b/NickvisionTubeConverter.GNOME/justfile
@@ -39,6 +39,7 @@ publish PREFIX LIB_DIR=lib: clean && (_install_extras PREFIX)
     echo -e "\033[1m# Publishing the app\033[0m"
     mkdir -p {{builddir}}{{PREFIX}}/{{LIB_DIR}}/{{app_id}}
     blueprint-compiler batch-compile Blueprints/ Blueprints/ Blueprints/*.blp
+    [ $? != 0 ] && exit 1
     dotnet publish -c Release {{project_name}}.GNOME.csproj \
         --runtime {{dotnet_runtime}} \
         --self-contained false \
@@ -69,6 +70,7 @@ publish-self-contained PREFIX LIB_DIR=lib: clean && (_install_extras PREFIX)
     echo -e "\033[1m# Publishing the app (self-contained)\033[0m"
     mkdir -p {{builddir}}{{PREFIX}}/{{LIB_DIR}}/{{app_id}}
     blueprint-compiler batch-compile Blueprints/ Blueprints/ Blueprints/*.blp
+    [ $? != 0 ] && exit 1
     dotnet publish -c Release {{project_name}}.GNOME.csproj \
         $([ -d "$FLATPAK_BUILDER_BUILDDIR/nuget-sources" ] && \
         echo "--source $FLATPAK_BUILDER_BUILDDIR/nuget-sources") \

--- a/NickvisionTubeConverter.Shared/Controllers/AddDownloadDialogController.cs
+++ b/NickvisionTubeConverter.Shared/Controllers/AddDownloadDialogController.cs
@@ -25,6 +25,10 @@ public enum DownloadCheckStatus
 public class AddDownloadDialogController
 {
     /// <summary>
+    /// Gets the AppInfo object
+    /// </summary>
+    public AppInfo AppInfo => AppInfo.Current;
+    /// <summary>
     /// The localizer to get translated strings from
     /// </summary>
     public Localizer Localizer { get; init; }


### PR DESCRIPTION
Seems like some DEs, including Xfce, require to explicitly set an icon for every window using [Gtk.Window.SetIconName](https://docs.gtk.org/gtk4/method.Window.set_icon_name.html) to be shown in taskbar and workspace switcher.

![](https://user-images.githubusercontent.com/117388856/226095632-6d2908e9-63d6-4ea1-b597-b69322383a1d.png)

Closes #103 