### PR TITLE
Work with special characters in filenames

### DIFF
--- a/NickvisionTubeConverter.GNOME/Blueprints/video_row.blp
+++ b/NickvisionTubeConverter.GNOME/Blueprints/video_row.blp
@@ -17,7 +17,7 @@ Adw.ActionRow _root {
   Gtk.MenuButton _editButton {
     icon-name: "document-edit-symbolic";
     valign: center;
-    tooltip-text: _("EditTitle");    
+    tooltip-text: _("EditTitle");
     popover: Gtk.Popover {
       Adw.Clamp {
         maximum-size: 300;

--- a/NickvisionTubeConverter.GNOME/Controls/VideoRow.cs
+++ b/NickvisionTubeConverter.GNOME/Controls/VideoRow.cs
@@ -7,6 +7,7 @@ namespace NickvisionTubeConverter.GNOME.Controls;
 public class VideoRow : Adw.ActionRow
 {
     private VideoInfo _videoInfo;
+    private readonly Gtk.EventControllerKey _titleKeyController;
 
     [Gtk.Connect] private readonly Gtk.CheckButton _downloadCheck;
     [Gtk.Connect] private readonly Gtk.Entry _titleEntry;
@@ -37,6 +38,10 @@ public class VideoRow : Adw.ActionRow
                 SetTitle(_videoInfo.Title);
             }
         };
+        _titleKeyController = Gtk.EventControllerKey.New();
+        _titleKeyController.SetPropagationPhase(Gtk.PropagationPhase.Capture);
+        _titleKeyController.OnKeyPressed += OnKeyPressed;
+        _titleEntry.AddController(_titleKeyController);
     }
 
     public VideoRow(VideoInfo videoInfo, Localizer localizer) : this(Builder.FromFile("video_row.ui", localizer), videoInfo)
@@ -48,5 +53,10 @@ public class VideoRow : Adw.ActionRow
     {
         SetTitle(_videoInfo.Title);
         _titleEntry.SetText(_videoInfo.Title);
+    }
+
+    private bool OnKeyPressed(Gtk.EventControllerKey sender, Gtk.EventControllerKey.KeyPressedSignalArgs e)
+    {
+        return e.Keyval == 47; // Disallow "/"
     }
 }

--- a/NickvisionTubeConverter.GNOME/Program.cs
+++ b/NickvisionTubeConverter.GNOME/Program.cs
@@ -44,7 +44,7 @@ public partial class Program
         _mainWindowController.AppInfo.ShortName = "Tube Converter";
         _mainWindowController.AppInfo.Description = $"{_mainWindowController.Localizer["Description"]}.";
         _mainWindowController.AppInfo.Version = "2023.3.1-next";
-        _mainWindowController.AppInfo.Changelog = "<ul><li></li></ul>";
+        _mainWindowController.AppInfo.Changelog = "<ul><li>Fixed an issue where the user could not download playlists with unavailable videos</li><li>Fixed an issue where the some videos could not be downloaded when embedding metadata</li><li>Fixed an issue where videos with invalid filename characters could not be downloaded</li><li>UX/UI improvements</li><li>Updated translations (Thanks everyone on Weblate!)</li></ul>";
         _mainWindowController.AppInfo.GitHubRepo = new Uri("https://github.com/nlogozzo/NickvisionTubeConverter");
         _mainWindowController.AppInfo.IssueTracker = new Uri("https://github.com/nlogozzo/NickvisionTubeConverter/issues/new");
         _mainWindowController.AppInfo.SupportUrl = new Uri("https://github.com/nlogozzo/NickvisionTubeConverter/discussions");

--- a/NickvisionTubeConverter.GNOME/org.nickvision.tubeconverter.metainfo.xml
+++ b/NickvisionTubeConverter.GNOME/org.nickvision.tubeconverter.metainfo.xml
@@ -38,7 +38,11 @@
   <releases>
     <release version="2023.3.1-next" date="2023-03-19">
       <description>
-        <p></p>
+        <p>- Fixed an issue where the user could not download playlists with unavailable videos</p>
+        <p>- Fixed an issue where the some videos could not be downloaded when embedding metadata</p>
+        <p>- Fixed an issue where videos with invalid filename characters could not be downloaded</p>
+        <p>- UX/UI improvements</p>
+        <p>- Updated translations (Thanks everyone on Weblate!)</p>
       </description>
     </release>
   </releases>

--- a/NickvisionTubeConverter.Shared/Controllers/AddDownloadDialogController.cs
+++ b/NickvisionTubeConverter.Shared/Controllers/AddDownloadDialogController.cs
@@ -68,7 +68,7 @@ public class AddDownloadDialogController
     /// <param name="videoUrlInfo">The VideoUrlInfo object</param>
     public void ToggleNumberVideos(VideoUrlInfo videoUrlInfo, bool toggled)
     {
-        var numberedRegex = new Regex(@"[0-9] - ", RegexOptions.None);
+        var numberedRegex = new Regex(@"[0-9]+ - ", RegexOptions.None);
         for (var i = 0; i < videoUrlInfo.Videos.Count; i++)
         {
             if (toggled)

--- a/NickvisionTubeConverter.Shared/Models/Download.cs
+++ b/NickvisionTubeConverter.Shared/Models/Download.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace NickvisionTubeConverter.Shared.Models;
@@ -108,6 +109,7 @@ public class Download
     {
         _progressCallback = progressCallback;
         IsDone = false;
+        Filename = Regex.Escape(Filename).Replace(@"\ ", " ");
         if (Directory.Exists(_tempDownloadPath))
         {
             Directory.Delete(_tempDownloadPath, true);

--- a/NickvisionTubeConverter.Shared/Models/Download.cs
+++ b/NickvisionTubeConverter.Shared/Models/Download.cs
@@ -109,7 +109,10 @@ public class Download
     {
         _progressCallback = progressCallback;
         IsDone = false;
-        Filename = Regex.Escape(Filename).Replace(@"\ ", " ");
+        if(!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            Filename = Regex.Escape(Filename).Replace(@"\ ", " ");
+        }
         if (Directory.Exists(_tempDownloadPath))
         {
             Directory.Delete(_tempDownloadPath, true);

--- a/NickvisionTubeConverter.Shared/Models/VideoUrlInfo.cs
+++ b/NickvisionTubeConverter.Shared/Models/VideoUrlInfo.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
 namespace NickvisionTubeConverter.Shared.Models;
@@ -125,6 +126,7 @@ public class VideoUrlInfo
                     var ytOpt = new Dictionary<string, dynamic>() {
                         { "quiet", true },
                         { "merge_output_format", "/" },
+                        { "windowsfilenames", RuntimeInformation.IsOSPlatform(OSPlatform.Windows) },
                         { "ignoreerrors", true }
                     };
                     Python.Runtime.PyDict? videoInfo = ytdlp.YoutubeDL(ytOpt).extract_info(url, download: false);

--- a/NickvisionTubeConverter.Shared/Models/VideoUrlInfo.cs
+++ b/NickvisionTubeConverter.Shared/Models/VideoUrlInfo.cs
@@ -154,7 +154,7 @@ public class VideoUrlInfo
                     else
                     {
                         var title = videoInfo.HasKey("title") ? (videoInfo["title"].As<string?>() ?? "Media") : "Media";
-                        foreach (var c in Path.GetInvalidPathChars())
+                        foreach (var c in Path.GetInvalidFileNameChars())
                         {
                             title = title.Replace(c, '_');
                         }

--- a/NickvisionTubeConverter.Shared/Models/VideoUrlInfo.cs
+++ b/NickvisionTubeConverter.Shared/Models/VideoUrlInfo.cs
@@ -143,12 +143,22 @@ public class VideoUrlInfo
                                 continue;
                             }
                             var entry = e.As<Python.Runtime.PyDict>();
-                            videoUrlInfo.Videos.Add(new VideoInfo(entry["webpage_url"].As<string>(), entry.HasKey("title") ? (entry["title"].As<string?>() ?? "Media") : "Media", true));
+                            var title = entry.HasKey("title") ? (entry["title"].As<string?>() ?? "Media") : "Media";
+                            foreach (var c in Path.GetInvalidFileNameChars())
+                            {
+                                title = title.Replace(c, '_');
+                            }
+                            videoUrlInfo.Videos.Add(new VideoInfo(entry["webpage_url"].As<string>(), title, true));
                         }
                     }
                     else
                     {
-                        videoUrlInfo.Videos.Add(new VideoInfo(videoInfo["webpage_url"].As<string>(), videoInfo.HasKey("title") ? (videoInfo["title"].As<string?>() ?? "Media") : "Media"));
+                        var title = videoInfo.HasKey("title") ? (videoInfo["title"].As<string?>() ?? "Media") : "Media";
+                        foreach (var c in Path.GetInvalidPathChars())
+                        {
+                            title = title.Replace(c, '_');
+                        }
+                        videoUrlInfo.Videos.Add(new VideoInfo(videoInfo["webpage_url"].As<string>(), title));
                     }
                     outFile.close();
                 }

--- a/NickvisionTubeConverter.WinUI/App.xaml.cs
+++ b/NickvisionTubeConverter.WinUI/App.xaml.cs
@@ -28,7 +28,7 @@ public partial class App : Application
         _mainWindowController.AppInfo.ShortName = "Tube Converter";
         _mainWindowController.AppInfo.Description = $"{_mainWindowController.Localizer["Description"]}.";
         _mainWindowController.AppInfo.Version = "2023.3.1-next";
-        _mainWindowController.AppInfo.Changelog = "- ";
+        _mainWindowController.AppInfo.Changelog = "- Fixed an issue where the user could not download playlists with unavailable videos\n- Fixed an issue where the some videos could not be downloaded when embedding metadata\n- Fixed an issue where videos with invalid filename characters could not be downloaded\n- Updated translations (Thanks everyone on Weblate!)";
         _mainWindowController.AppInfo.GitHubRepo = new Uri("https://github.com/nlogozzo/NickvisionTubeConverter");
         _mainWindowController.AppInfo.IssueTracker = new Uri("https://github.com/nlogozzo/NickvisionTubeConverter/issues/new");
         _mainWindowController.AppInfo.SupportUrl = new Uri("https://github.com/nlogozzo/NickvisionTubeConverter/discussions");

--- a/NickvisionTubeConverter.WinUI/Controls/VideoRow.xaml
+++ b/NickvisionTubeConverter.WinUI/Controls/VideoRow.xaml
@@ -19,7 +19,7 @@
 
                 <Button.Flyout>
                     <Flyout Placement="Bottom">
-                        <TextBox PlaceholderText="{Binding OriginalTitle}" Text="{Binding Title, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                        <TextBox x:name="TxtTitle" PlaceholderText="{Binding OriginalTitle}" Text="{Binding Title, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" TextChanged="TxtTitle_TextChanged"/>
                     </Flyout>
                 </Button.Flyout>
             </Button>

--- a/NickvisionTubeConverter.WinUI/Controls/VideoRow.xaml
+++ b/NickvisionTubeConverter.WinUI/Controls/VideoRow.xaml
@@ -19,7 +19,7 @@
 
                 <Button.Flyout>
                     <Flyout Placement="Bottom">
-                        <TextBox x:name="TxtTitle" PlaceholderText="{Binding OriginalTitle}" Text="{Binding Title, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" TextChanged="TxtTitle_TextChanged"/>
+                        <TextBox x:Name="TxtTitle" PlaceholderText="{Binding OriginalTitle}" Text="{Binding Title, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" TextChanged="TxtTitle_TextChanged"/>
                     </Flyout>
                 </Button.Flyout>
             </Button>

--- a/NickvisionTubeConverter.WinUI/Controls/VideoRow.xaml.cs
+++ b/NickvisionTubeConverter.WinUI/Controls/VideoRow.xaml.cs
@@ -32,14 +32,9 @@ public sealed partial class VideoRow : UserControl
     /// <param name="e">TextChangedEventArgs</param>
     private void TxtTitle_TextChanged(object sender, TextChangedEventArgs e)
     {
-        if (!_constructing)
+        foreach (var c in Path.GetInvalidFileNameChars())
         {
-            var position = TxtTitle.SelectionStart;
-            foreach (var c in Path.GetInvalidFileNameChars())
-            {
-                TxtTitle.Text = TxtTitle.Text.Replace(c, '_');
-            }
-            TxtAmount.SelectionStart = position - 1;
+            TxtTitle.Text = TxtTitle.Text.Replace(c, '_');
         }
     }
 }

--- a/NickvisionTubeConverter.WinUI/Controls/VideoRow.xaml.cs
+++ b/NickvisionTubeConverter.WinUI/Controls/VideoRow.xaml.cs
@@ -1,6 +1,7 @@
 using Microsoft.UI.Xaml.Controls;
 using NickvisionTubeConverter.Shared.Helpers;
 using NickvisionTubeConverter.Shared.Models;
+using System.IO;
 
 namespace NickvisionTubeConverter.WinUI.Controls;
 
@@ -22,5 +23,23 @@ public sealed partial class VideoRow : UserControl
         _videoInfo = videoInfo;
         DataContext = _videoInfo;
         ToolTipService.SetToolTip(BtnEdit, localizer["EditTitle"]);
+    }
+
+    /// <summary>
+    /// Occurs when the title textbox is changed
+    /// </summary>
+    /// <param name="sender">object</param>
+    /// <param name="e">TextChangedEventArgs</param>
+    private void TxtTitle_TextChanged(object sender, TextChangedEventArgs e)
+    {
+        if (!_constructing)
+        {
+            var position = TxtTitle.SelectionStart;
+            foreach (var c in Path.GetInvalidFileNameChars())
+            {
+                TxtTitle.Text = TxtTitle.Text.Replace(c, '_');
+            }
+            TxtAmount.SelectionStart = position - 1;
+        }
     }
 }


### PR DESCRIPTION
Closes #120 
Requires changes in WinUI to disallow manual entering of characters from `Path.GetInvalidFilenameCharacters()`