### PR TITLE
Fix characters escaping in filenames

### DIFF
--- a/NickvisionTubeConverter.Shared/Models/Download.cs
+++ b/NickvisionTubeConverter.Shared/Models/Download.cs
@@ -111,7 +111,7 @@ public class Download
         IsDone = false;
         if(!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            Filename = Regex.Escape(Filename).Replace(@"\ ", " ");
+            Filename = Regex.Escape(Filename).Replace(@"\ ", " ").Replace(@"\?", "?").Replace(@"\.", ".");
         }
         if (Directory.Exists(_tempDownloadPath))
         {


### PR DESCRIPTION
Related: #120 https://github.com/nlogozzo/NickvisionTubeConverter/issues/129#issuecomment-1487229074

`?` and `.` have special meanings in regex patterns and so are escaped by `Regex.Escape`, but we don't want this because in filenames these characters are usually safe and have special meanings only in certain contexts that are not possible in TC, for example:
* `./` will never appear because `/` is completely disallowed and replaced with `_`
* `$?` gives the exit code of previous command in POSIX shells, but `$` is escaped and so `\$?` will be treated literally (you can try `echo $?` and `echo \$?` in a shell and see the difference).