### PR TITLE
Fix Issue #113

### DIFF
--- a/NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs
+++ b/NickvisionTubeConverter.WinUI/Views/AddDownloadDialog.xaml.cs
@@ -160,6 +160,7 @@ public sealed partial class AddDownloadDialog : ContentDialog
         var fileType = (MediaFileType)CmbFileType.SelectedIndex;
         _initializeWithWindow(folderPicker);
         folderPicker.SuggestedStartLocation = fileType.GetIsVideo() ? PickerLocationId.VideosLibrary : PickerLocationId.MusicLibrary;
+        folderPicker.FileTypeFilter.Add("*");
         var folder = await folderPicker.PickSingleFolderAsync();
         if (folder != null)
         {


### PR DESCRIPTION
Fixed Issue: Unable to change the file destination folder on Windows 10

In Windows 10 the FolderPicker requires at least one file type filter specified.

Closes #113 