### PR TITLE
Improve a sentence in the Vietnamese translation

### DIFF
--- a/NickvisionTubeConverter.Shared/Resources/Strings.vi.resx
+++ b/NickvisionTubeConverter.Shared/Resources/Strings.vi.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
@@ -283,7 +283,7 @@ Bạn có chắc bạn muốn đóng Tube Converter và hủy các quá trình �
 		<value>Nếu được đánh dấu, siêu dữ liệu của video sẽ được bao gồm trong tệp tải xuống</value>
   </data>
   <data name="MaxNumberOfActiveDownloads" xml:space="preserve">
-		<value>Số lượng Tối đa Tải xuống Đồng thời</value>
+		<value>Giới hạn Số lượng Tải xuống Đồng thời</value>
   </data>
   <!--Shortcuts Dialog-->
   <data name="Application.Shortcut" xml:space="preserve">


### PR DESCRIPTION
The original sentence was a direct English to Vietnamese translation, but it sounded awkward.