### PR TITLE
Declare adaptiveness in metainfo and .desktop file

### DIFF
--- a/NickvisionTubeConverter.GNOME/org.nickvision.tubeconverter.desktop
+++ b/NickvisionTubeConverter.GNOME/org.nickvision.tubeconverter.desktop
@@ -10,3 +10,5 @@ Categories=AudioVideo;Network;
 X-GNOME-UsesNotifications=true
 StartupNotify=true
 DBusActivatable=true
+# Translators: Do NOT translate or transliterate this text (these are enum types)!
+X-Purism-FormFactor=Workstation;Mobile;

--- a/NickvisionTubeConverter.GNOME/org.nickvision.tubeconverter.metainfo.xml
+++ b/NickvisionTubeConverter.GNOME/org.nickvision.tubeconverter.metainfo.xml
@@ -42,6 +42,12 @@
     <binary>org.nickvision.tubeconverter</binary>
     <binary>NickvisionTubeConverter.GNOME</binary>
   </provides>
+
+  <custom>
+    <value key="Purism::form_factor">workstation</value>
+    <value key="Purism::form_factor">mobile</value>
+  </custom>
+  
   <releases>
     <release version="2023.4.1-next" date="2023-04-03">
       <description>


### PR DESCRIPTION
As specified in https://puri.sm/posts/specify-form-factors-in-your-librem-5-apps/ both metainfo and .desktop file need to have declared adaptiveness to mobile sizes.

This declaration in .desktop file would allow Phosh to list Denaro when showing which apps are adaptive to mobile size, in the app drawer and the declaration in metainfo allows sites like https://apps.gnome.org to show that it supports mobile devices.