### PR TITLE
Add TubeConverter yt-dlp plugin to use for metadata embedding

### DIFF
--- a/NickvisionTubeConverter.Shared/Helpers/DependencyManager.cs
+++ b/NickvisionTubeConverter.Shared/Helpers/DependencyManager.cs
@@ -105,6 +105,11 @@ internal static class DependencyManager
                 Python.Runtime.Runtime.PythonDLL = process.StandardOutput.ReadToEnd().Trim();
                 process.WaitForExit();
             }
+            var pluginPath = $"{Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)}{Path.DirectorySeparatorChar}yt-dlp{Path.DirectorySeparatorChar}plugins{Path.DirectorySeparatorChar}tubeconverter{Path.DirectorySeparatorChar}yt_dlp_plugins{Path.DirectorySeparatorChar}postprocessor{Path.DirectorySeparatorChar}tubeconverter.py";
+            Directory.CreateDirectory(pluginPath.Substring(0, pluginPath.LastIndexOf(Path.DirectorySeparatorChar)));
+            using var pluginResource = Assembly.GetExecutingAssembly().GetManifestResourceStream("NickvisionTubeConverter.Shared.Resources.tubeconverter.py")!;
+            using var pluginFile = new FileStream(pluginPath, FileMode.Create, FileAccess.Write);
+            pluginResource.CopyTo(pluginFile);
             return true;
         }
         catch (Exception e)

--- a/NickvisionTubeConverter.Shared/Models/Download.cs
+++ b/NickvisionTubeConverter.Shared/Models/Download.cs
@@ -193,7 +193,7 @@ public class Download
                         ytOpt.Add("writethumbnail", true);
                         postProcessors.Add(new Dictionary<string, dynamic>() { { "key", "EmbedThumbnail" } });
                     }
-                    postProcessors.Insert(0, new Dictionary<string, dynamic>() { { "key", "FFmpegMetadata" }, { "add_metadata", true } });
+                    postProcessors.Insert(0, new Dictionary<string, dynamic>() { { "key", "TCMetadata" }, { "add_metadata", true } });
                 }
                 if (postProcessors.Count != 0)
                 {

--- a/NickvisionTubeConverter.Shared/NickvisionTubeConverter.Shared.csproj
+++ b/NickvisionTubeConverter.Shared/NickvisionTubeConverter.Shared.csproj
@@ -10,10 +10,12 @@
 		<None Remove="Resources\org.nickvision.tubeconverter-symbolic.svg" />
 		<None Remove="Resources\org.nickvision.tubeconverter.png" />
 		<None Remove="Resources\org.nickvision.tubeconverter.svg" />
+		<None Remove="Resources\tubeconverter.py" />
 		<None Remove="Resources\yt_dlp-any.whl" />
 	</ItemGroup>
 
 	<ItemGroup>
+	  <EmbeddedResource Include="Resources\tubeconverter.py" />
 	  <EmbeddedResource Include="Resources\yt_dlp-any.whl" />
 	</ItemGroup>
 

--- a/NickvisionTubeConverter.Shared/Resources/tubeconverter.py
+++ b/NickvisionTubeConverter.Shared/Resources/tubeconverter.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+from yt_dlp.postprocessor.ffmpeg import FFmpegMetadataPP
+
+class TCMetadataPP(FFmpegMetadataPP):
+    def run(self, info):
+        try:
+            success = super().run(info)
+            return success
+        except:
+            self.to_screen('WARNING: Failed to embed metadata')
+            return [], info


### PR DESCRIPTION
Closes #160 

yt-dlp extractors work great in most cases, but for some sites they can generate invalid metadata that ffmpeg fails to embed. In case of the video from #160, there is wrong chapters data:
```
...{'start_time': 1557.55, 'end_time': 1087.67, 'title': 'Alles ist Chemie'}, {'start_time': 1087.67, 'end_time': 1799, 'title': 'Natürlich=Sicher?'}
```
Notice that start time > end time. Also, chapters are actually in wrong order.
While it is expected when "Embed metadata" setting is enabled to get metadata embedded into a file, if there's something wrong we don't want to ruin the whole process. But at the same time we want to stop if there are errors in another postprocessors, so we can't set `ignoreerrors` to true.
As a solution, I added yt-dlp plugin with postprocessor that is based on `FFmpegMetadata`. It changes only one thing: if embedding fails, it shows a warning in the log but doesn't stop the whole process, so other postprocessors can do their job.

![Снимок экрана от 2023-04-05 05-53-22](https://user-images.githubusercontent.com/117388856/229974657-ed6f4596-1c6b-44b0-b82d-22fe2792dec6.png)

According to yt-dlp docs, plugins should be installed [in specific places](https://github.com/yt-dlp/yt-dlp#installing-plugins). In our case, in `${APPDATA/XDG_CONFIG_HOME}/yt-dlp/plugins/tubeconverter/yt_dlp_plugins/`. The plugin is installed every time the app starts - this is made on purpose to guarantee that the file has the content it should have. And since the file is only 299 bytes in size, it's not IO- or CPU-intensive task.