### PR TITLE
GNOME - Correctly close the app when background activity is reported

### DIFF
--- a/NickvisionTubeConverter.GNOME/Views/MainWindow.cs
+++ b/NickvisionTubeConverter.GNOME/Views/MainWindow.cs
@@ -62,25 +62,32 @@ public partial class MainWindow : Adw.ApplicationWindow
         _bus = g_bus_get_sync(2, IntPtr.Zero, IntPtr.Zero); // 2 = session bus
         _backgroundSourceFunc = (d) =>
         {
-            if (_isBackgroundStatusReported)
+            try
             {
-                var builder = g_variant_builder_new(g_variant_type_new("a{sv}"));
-                g_variant_builder_add(builder, "{sv}", "message", g_variant_new_string(_controller.GetBackgroundActivityReport()));
-                g_dbus_connection_call(_bus,
-                    "org.freedesktop.portal.Desktop", // Bus name
-                    "/org/freedesktop/portal/desktop", // Object path
-                    "org.freedesktop.portal.Background", // Interface name
-                    "SetStatus", // Method name
-                    g_variant_new("(a{sv})", builder), // Parameters
-                    IntPtr.Zero, // Reply type
-                    0, // Flags
-                    -1, // Timeout
-                    IntPtr.Zero, // Cancellable
-                    IntPtr.Zero, // Callback
-                    IntPtr.Zero); // User data
-                g_variant_builder_unref(builder);
+                if (_isBackgroundStatusReported)
+                {
+                    var builder = g_variant_builder_new(g_variant_type_new("a{sv}"));
+                    g_variant_builder_add(builder, "{sv}", "message", g_variant_new_string(_controller.GetBackgroundActivityReport()));
+                    g_dbus_connection_call(_bus,
+                        "org.freedesktop.portal.Desktop", // Bus name
+                        "/org/freedesktop/portal/desktop", // Object path
+                        "org.freedesktop.portal.Background", // Interface name
+                        "SetStatus", // Method name
+                        g_variant_new("(a{sv})", builder), // Parameters
+                        IntPtr.Zero, // Reply type
+                        0, // Flags
+                        -1, // Timeout
+                        IntPtr.Zero, // Cancellable
+                        IntPtr.Zero, // Callback
+                        IntPtr.Zero); // User data
+                    g_variant_builder_unref(builder);
+                }
+                return _isBackgroundStatusReported;
             }
-            return _isBackgroundStatusReported;
+            catch
+            {
+                return false;
+            }
         };
         _controller.RunInBackgroundChanged += RunInBackgroundChanged;
         SetTitle(_controller.AppInfo.ShortName);


### PR DESCRIPTION
Without this change, when background activity is reported the app closes with the error:
```
Unhandled exception. System.ObjectDisposedException: Cannot access a closed resource set.
   at System.Resources.RuntimeResourceSet.GetObject(String key, Boolean ignoreCase, Boolean isString)
   at System.Resources.RuntimeResourceSet.GetString(String key)
   at NickvisionTubeConverter.Shared.Helpers.Localizer.GetString(String name) in /var/home/user/Проекты/NickvisionTubeConverter/NickvisionTubeConverter.Shared/Helpers/Localizer.cs:line 74
   at NickvisionTubeConverter.Shared.Helpers.Localizer.get_Item(String name, Boolean plural) in /var/home/user/Проекты/NickvisionTubeConverter/NickvisionTubeConverter.Shared/Helpers/Localizer.cs:line 23
   at NickvisionTubeConverter.Shared.Controllers.MainWindowController.GetBackgroundActivityReport() in /var/home/user/Проекты/NickvisionTubeConverter/NickvisionTubeConverter.Shared/Controllers/MainWindowController.cs:line 332
   at NickvisionTubeConverter.GNOME.Views.MainWindow.<.ctor>b__27_0(IntPtr d) in /var/home/user/Проекты/NickvisionTubeConverter/NickvisionTubeConverter.GNOME/Views/MainWindow.cs:line 68
```