### PR TITLE
Logging, unescaping and overwriting improvements

### DIFF
--- a/NickvisionTubeConverter.GNOME/Blueprints/download_row.blp
+++ b/NickvisionTubeConverter.GNOME/Blueprints/download_row.blp
@@ -169,7 +169,9 @@ Adw.Bin _root {
           margin-end: 6;
           margin-bottom: 6;
           halign: start;
+          valign: start;
           wrap: true;
+          wrap-mode: char;
           selectable: true;
         };
 

--- a/NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs
+++ b/NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs
@@ -36,15 +36,15 @@ public partial class DownloadRow : Adw.Bin, IDownloadRowControl
 
     private readonly Localizer _localizer;
     private readonly Download _download;
+    private readonly GSourceFunc _runStartCallback;
+    private readonly GSourceFunc _runEndCallback;
+    private readonly GSourceFunc _stopCallback;
+    private readonly GSourceFunc _updateLogCallback;
+    private readonly GSourceFunc _processingCallback;
+    private GSourceFunc? _downloadingCallback;
     private bool? _previousEmbedMetadata;
     private bool _wasStopped;
     private DownloadProgressStatus _progressStatus;
-    private GSourceFunc _runStartCallback;
-    private GSourceFunc _runEndCallback;
-    private GSourceFunc _stopCallback;
-    private GSourceFunc _updateLogCallback;
-    private GSourceFunc? _processingCallback;
-    private GSourceFunc? _downloadingCallback;
     private string _logMessage;
     private bool _processingCallbackRunning;
     private Action<NotificationSentEventArgs> _sendNotificationCallback;
@@ -193,6 +193,15 @@ public partial class DownloadRow : Adw.Bin, IDownloadRowControl
             vadjustment.SetValue(vadjustment.GetUpper() - vadjustment.GetPageSize());
             return false;
         };
+        _processingCallback = (d) =>
+        {
+            _progressBar.Pulse();
+            if (_progressStatus != DownloadProgressStatus.Processing || IsDone)
+            {
+                _processingCallbackRunning = false;
+            }
+            return _processingCallbackRunning;
+        };
     }
 
     /// <summary>
@@ -245,15 +254,6 @@ public partial class DownloadRow : Adw.Bin, IDownloadRowControl
                     _progressLabel.SetText(_localizer["DownloadState", "Processing"]);
                     Progress = 1.0;
                     Speed = 0.0;
-                    _processingCallback = (d) =>
-                    {
-                        _progressBar.Pulse();
-                        if (_progressStatus != DownloadProgressStatus.Processing || IsDone)
-                        {
-                            _processingCallbackRunning = false;
-                        }
-                        return _processingCallbackRunning;
-                    };
                     if (!_processingCallbackRunning)
                     {
                         _processingCallbackRunning = true;

--- a/NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs
+++ b/NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs
@@ -219,7 +219,7 @@ public partial class DownloadRow : Adw.Bin, IDownloadRowControl
         _wasStopped = false;
         FinishedWithError = false;
         g_main_context_invoke(0, _runStartCallback, 0);
-        var success = await _download.RunAsync(embedMetadata, (state) =>
+        var success = await _download.RunAsync(embedMetadata, _localizer, (state) =>
         {
             _progressStatus = state.Status;
             _logMessage = state.Log + "\n";

--- a/NickvisionTubeConverter.Shared/Models/Download.cs
+++ b/NickvisionTubeConverter.Shared/Models/Download.cs
@@ -208,6 +208,7 @@ public class Download
                 }
                 catch (Exception e)
                 {
+                    Filename = Regex.Unescape(Filename);
                     Console.WriteLine(e);
                     IsDone = true;
                     outFile.close();

--- a/NickvisionTubeConverter.Shared/Models/Download.cs
+++ b/NickvisionTubeConverter.Shared/Models/Download.cs
@@ -104,8 +104,9 @@ public class Download
     /// </summary>
     /// <param name="embedMetadata">Whether or not to embed video metadata in the downloaded file</param>
     /// <param name="progressCallback">A callback function for DownloadProgressState</param>
+    /// <param name="localizer">Localizer</param>
     /// <returns>True if successful, else false</returns>
-    public async Task<bool> RunAsync(bool embedMetadata, Action<DownloadProgressState>? progressCallback = null)
+    public async Task<bool> RunAsync(bool embedMetadata, Localizer localizer, Action<DownloadProgressState>? progressCallback = null)
     {
         _progressCallback = progressCallback;
         IsDone = false;
@@ -118,7 +119,7 @@ public class Download
                     Status = DownloadProgressStatus.Other,
                     Progress = 0.0,
                     Speed = 0.0,
-                    Log = "File already exists, and overwriting is disallowed"
+                    Log = localizer["FileExistsError"]
                 });
             }
             return false;

--- a/NickvisionTubeConverter.Shared/Models/Download.cs
+++ b/NickvisionTubeConverter.Shared/Models/Download.cs
@@ -202,7 +202,7 @@ public class Download
                     if (_fileType.GetSupportsThumbnails())
                     {
                         ytOpt.Add("writethumbnail", true);
-                        postProcessors.Add(new Dictionary<string, dynamic>() { { "key", "EmbedThumbnail" } });
+                        postProcessors.Add(new Dictionary<string, dynamic>() { { "key", "TCEmbedThumbnail" } });
                     }
                     postProcessors.Insert(0, new Dictionary<string, dynamic>() { { "key", "TCMetadata" }, { "add_metadata", true } });
                 }

--- a/NickvisionTubeConverter.Shared/Models/Download.cs
+++ b/NickvisionTubeConverter.Shared/Models/Download.cs
@@ -128,10 +128,6 @@ public class Download
         {
             Filename = Regex.Escape(Filename);
         }
-        if (Directory.Exists(_tempDownloadPath) && _overwriteFiles)
-        {
-            Directory.Delete(_tempDownloadPath, true);
-        }
         Directory.CreateDirectory(_tempDownloadPath);
         dynamic outFile = PythonHelpers.SetConsoleOutputFilePath(_logPath);
         return await Task.Run(() =>

--- a/NickvisionTubeConverter.Shared/Models/Download.cs
+++ b/NickvisionTubeConverter.Shared/Models/Download.cs
@@ -216,6 +216,10 @@ public class Download
                 try
                 {
                     Python.Runtime.PyObject success_code = ytdlp.YoutubeDL(ytOpt).download(new List<string>() { VideoUrl });
+                    if ((success_code.As<int?>() ?? 1) != 0)
+                    {
+                        Filename = Regex.Unescape(Filename);
+                    }
                     ForceUpdateLog();
                     IsDone = true;
                     outFile.close();

--- a/NickvisionTubeConverter.Shared/Models/Download.cs
+++ b/NickvisionTubeConverter.Shared/Models/Download.cs
@@ -109,6 +109,20 @@ public class Download
     {
         _progressCallback = progressCallback;
         IsDone = false;
+        if (File.Exists($"{SaveFolder}{Path.DirectorySeparatorChar}{Filename}") && !_overwriteFiles)
+        {
+            if (_progressCallback != null)
+            {
+                _progressCallback(new DownloadProgressState()
+                {
+                    Status = DownloadProgressStatus.Other,
+                    Progress = 0.0,
+                    Speed = 0.0,
+                    Log = "File already exists, and overwriting is disallowed"
+                });
+            }
+            return false;
+        }
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
             Filename = Regex.Escape(Filename);
@@ -293,7 +307,7 @@ public class Download
                 File.Move(path.As<string>(), $"{directory}{Path.DirectorySeparatorChar}{Filename}", _overwriteFiles);
             }
         }
-        catch
+        catch (Exception e)
         {
             Console.WriteLine($"Failed to unescape file: {path.As<string?>()}");
         }

--- a/NickvisionTubeConverter.Shared/Models/Download.cs
+++ b/NickvisionTubeConverter.Shared/Models/Download.cs
@@ -113,7 +113,7 @@ public class Download
         {
             Filename = Regex.Escape(Filename);
         }
-        if (Directory.Exists(_tempDownloadPath))
+        if (Directory.Exists(_tempDownloadPath) && _overwriteFiles)
         {
             Directory.Delete(_tempDownloadPath, true);
         }

--- a/NickvisionTubeConverter.Shared/Resources/Strings.resx
+++ b/NickvisionTubeConverter.Shared/Resources/Strings.resx
@@ -361,6 +361,10 @@
 		<value>No downloads running</value>
 	</data>
 
+	<data name="FileExistsError" xml:space="preserve">
+		<value>File already exists, and overwriting is disallowed</value>
+	</data>
+
 	<!--VideoRow-->
 	<data name="EditTitle" xml:space="preserve">
 		<value>Edit Title</value>

--- a/NickvisionTubeConverter.Shared/Resources/tubeconverter.py
+++ b/NickvisionTubeConverter.Shared/Resources/tubeconverter.py
@@ -1,11 +1,27 @@
 #!/usr/bin/env python3
 from yt_dlp.postprocessor.ffmpeg import FFmpegMetadataPP
+from yt_dlp.postprocessor.embedthumbnail import EmbedThumbnailPP
 
 class TCMetadataPP(FFmpegMetadataPP):
     def run(self, info):
         try:
             success = super().run(info)
             return success
-        except:
+        except Exception as e:
+            self.to_screen(e)
             self.to_screen('WARNING: Failed to embed metadata')
             return [], info
+
+class TCEmbedThumbnailPP(EmbedThumbnailPP):
+    def run(self, info):
+        try:
+            success = super().run(info)
+            return success
+        except Exception as e:
+            self.to_screen(e)
+            self.to_screen('WARNING: Failed to embed thumbnail')
+            idx = next((-i for i, t in enumerate(info['thumbnails'][::-1], 1) if t.get('filepath')), None)
+            thumbnail_filename = info['thumbnails'][idx]['filepath']
+            self._delete_downloaded_files(thumbnail_filename, info=info)
+            return [], info
+

--- a/NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs
+++ b/NickvisionTubeConverter.WinUI/Controls/DownloadRow.xaml.cs
@@ -110,7 +110,7 @@ public sealed partial class DownloadRow : UserControl, IDownloadRowControl
         BtnOpenFile.Visibility = Visibility.Collapsed;
         BtnOpenSaveFolder.Visibility = Visibility.Collapsed;
         ProgBar.Value = 0;
-        var success = await _download.RunAsync(embedMetadata, (state) =>
+        var success = await _download.RunAsync(embedMetadata, _localizer, (state) =>
         {
             App.MainWindow!.DispatcherQueue.TryEnqueue(() =>
             {


### PR DESCRIPTION
* Don't clean temp dir to avoid redownloading files from the beginning in case the download was restarted
* Check if final file already exists when `_overwriteFiles` is false to prevent download that can't in fact be successfully finished
* Unescape filename on error, closes #152
* Improve logging, closes #161 
    There were 3 problems with logs:
    1. The first character was not shown
    2. Logs weren't completely shown in the app in case of error (because we only updated logs from the hook, now it's also updated on error)
    3. Logs are not always in sync with what is actually happening. This is not fixed. It's odd, yt-dlp calls hook for download after it prints the output, but for postprocessing it's the opposite. In result, `progressCallback` is called first, and only then the file with the log is changed, so it will be shown on next hook call. I was thinking how to workaround this, but tbh I think it doesn't worth the effort, the purpose of logs is to see what happened on error, and in this case the full log is shown as I said earlier
* EmbedThumbnail postprocessor replaced with custom one that ignores errors (similar to TCEmbedMetadata)