### PR TITLE
Drop blueprint-compiler

### DIFF
--- a/flatpak/org.nickvision.tubeconverter.json
+++ b/flatpak/org.nickvision.tubeconverter.json
@@ -199,20 +199,6 @@
             ]
         },
         {
-            "name": "blueprint-compiler",
-            "buildsystem": "meson",
-            "cleanup": [
-                "*"
-            ],
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://gitlab.gnome.org/jwestman/blueprint-compiler",
-                    "tag": "v0.16.0"
-                }
-            ]
-        },
-        {
             "name": "libxmlplusplus",
             "buildsystem": "meson",
             "config-opts": [


### PR DESCRIPTION
Blueprint compiler is now part of GNOME runtime 49.

Fixes: https://github.com/flathub/org.nickvision.tubeconverter/pull/191

Fixes #1556