### PR TITLE
Fix and improve `chmod` in "YtdlpExecutableService.cs" for better permissions

### DIFF
--- a/Nickvision.Parabolic.Shared/Services/YtdlpExecutableService.cs
+++ b/Nickvision.Parabolic.Shared/Services/YtdlpExecutableService.cs
@@ -97,13 +97,8 @@ public class YtdlpExecutableService : IYtdlpExecutableService
             {
                 using var process = new Process()
                 {
-                    StartInfo = new ProcessStartInfo
+                    StartInfo = new ProcessStartInfo("chmod", ["0755", path])
                     {
-                        FileName = "chmod",
-                        ArgumentList = [
-                          "0755",
-                          path
-                        ],
                         UseShellExecute = false,
                         CreateNoWindow = true,
                     }


### PR DESCRIPTION
It was previously returning a "missing operand" error. This ensures that `chmod` actually gives executable permissions to `yt-dlp` after downloading it.

I also tested this patch on my end while I was fixing the Fedora package (that I maintain) for this project. It works without any errors.

You can try it out for yourself, with this patch command. I don't know your dev environment, so feel free to replace "path/to" with an actual filepath.

```sh
patch -p1 -s --fuzz=0 --no-backup-if-mismatch -f < path/to/fix_chmod_cmd.patch
```

[fix_chmod_cmd.patch](https://github.com/user-attachments/files/25280359/fix_chmod_cmd.patch)

