### PR TITLE
Fix broken homepage link

### DIFF
--- a/resources/linux/org.nickvision.tubeconverter.metainfo.xml
+++ b/resources/linux/org.nickvision.tubeconverter.metainfo.xml
@@ -40,7 +40,7 @@
     <color type="primary" scheme_preference="light">#ffc199</color>
     <color type="primary" scheme_preference="dark">#ae0010</color>
   </branding>
-  <url type="homepage">https://nickvision.org/Parabolic.html</url>
+  <url type="homepage">https://nickvision.org/parabolic.html</url>
   <url type="bugtracker">https://github.com/NickvisionApps/Parabolic/issues</url>
   <url type="donation">https://github.com/sponsors/nlogozzo</url>
   <url type="translate">https://github.com/NickvisionApps/Parabolic/blob/master/CONTRIBUTING.md#providing-translations</url>


### PR DESCRIPTION
Homepage link on Flatpak page (https://flathub.org/en/apps/org.nickvision.tubeconverter) was broken due to uppercase "Parabolic.html" instead of "parabolic.html"